### PR TITLE
chore: normalize C# formatting to spaces

### DIFF
--- a/src/AppTemplate.Core/Infrastructure/ApplicationReleaseInfo.cs
+++ b/src/AppTemplate.Core/Infrastructure/ApplicationReleaseInfo.cs
@@ -2,5 +2,5 @@ namespace AppTemplate.Core.Infrastructure;
 
 public static class ApplicationReleaseInfo
 {
-	public const int DataVersion = 1;
+    public const int DataVersion = 1;
 }

--- a/src/AppTemplate.Core/Infrastructure/IAppUpdater.cs
+++ b/src/AppTemplate.Core/Infrastructure/IAppUpdater.cs
@@ -2,5 +2,5 @@ namespace AppTemplate.Core.Infrastructure;
 
 public interface IAppUpdater
 {
-	Task EnsureAppUpToDateAsync();
+    Task EnsureAppUpToDateAsync();
 }

--- a/src/AppTemplate.Core/Infrastructure/IApplication.cs
+++ b/src/AppTemplate.Core/Infrastructure/IApplication.cs
@@ -2,9 +2,9 @@ namespace AppTemplate.Core.Infrastructure;
 
 public interface IApplication
 {
-	ApplicationTheme RequestedTheme { get; }
+    ApplicationTheme RequestedTheme { get; }
 
-	ResourceDictionary Resources { get; }
+    ResourceDictionary Resources { get; }
 
-	void Exit();
+    void Exit();
 }

--- a/src/AppTemplate.Core/Infrastructure/IoC.cs
+++ b/src/AppTemplate.Core/Infrastructure/IoC.cs
@@ -4,32 +4,32 @@ namespace AppTemplate.Core.Infrastructure;
 
 public static class IoC
 {
-	private static IServiceProvider? _serviceProvider;
+    private static IServiceProvider? _serviceProvider;
 
-	public static void SetProvider(IServiceProvider serviceProvider)
-	{
-		_serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-	}
+    public static void SetProvider(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+    }
 
-	public static T? GetService<T>() where T : class
-	{
-		EnsureServiceProvider();
-		return (T?)_serviceProvider.GetService(typeof(T));
-	}
+    public static T? GetService<T>() where T : class
+    {
+        EnsureServiceProvider();
+        return (T?)_serviceProvider.GetService(typeof(T));
+    }
 
-	public static T GetRequiredService<T>() where T : class
-	{
-		EnsureServiceProvider();
-		return (T?)_serviceProvider.GetService(typeof(T))
-			?? throw new InvalidOperationException($"Service of type {typeof(T).Name} is not registered.");
-	}
+    public static T GetRequiredService<T>() where T : class
+    {
+        EnsureServiceProvider();
+        return (T?)_serviceProvider.GetService(typeof(T))
+            ?? throw new InvalidOperationException($"Service of type {typeof(T).Name} is not registered.");
+    }
 
-	[MemberNotNull(nameof(_serviceProvider))]
-	private static void EnsureServiceProvider()
-	{
-		if (_serviceProvider is null)
-		{
-			throw new InvalidOperationException("Service provider was not yet initialized. Call IoC.SetProvider() first.");
-		}
-	}
+    [MemberNotNull(nameof(_serviceProvider))]
+    private static void EnsureServiceProvider()
+    {
+        if (_serviceProvider is null)
+        {
+            throw new InvalidOperationException("Service provider was not yet initialized. Call IoC.SetProvider() first.");
+        }
+    }
 }

--- a/src/AppTemplate.Core/Navigation/NavigationInfoAttribute.cs
+++ b/src/AppTemplate.Core/Navigation/NavigationInfoAttribute.cs
@@ -3,13 +3,13 @@ namespace AppTemplate.Core.Navigation;
 [AttributeUsage(AttributeTargets.Class, Inherited = false)]
 public sealed class NavigationInfoAttribute : Attribute
 {
-	public NavigationSection Section { get; }
+    public NavigationSection Section { get; }
 
-	public NavigationTransition Transition { get; }
+    public NavigationTransition Transition { get; }
 
-	public NavigationInfoAttribute(NavigationSection section, NavigationTransition transition = NavigationTransition.Default)
-	{
-		Section = section;
-		Transition = transition;
-	}
+    public NavigationInfoAttribute(NavigationSection section, NavigationTransition transition = NavigationTransition.Default)
+    {
+        Section = section;
+        Transition = transition;
+    }
 }

--- a/src/AppTemplate.Core/Navigation/NavigationSection.cs
+++ b/src/AppTemplate.Core/Navigation/NavigationSection.cs
@@ -2,6 +2,6 @@ namespace AppTemplate.Core.Navigation;
 
 public enum NavigationSection
 {
-	Main,
-	Settings,
+    Main,
+    Settings,
 }

--- a/src/AppTemplate.Core/Navigation/NavigationTransition.cs
+++ b/src/AppTemplate.Core/Navigation/NavigationTransition.cs
@@ -2,9 +2,9 @@ namespace AppTemplate.Core.Navigation;
 
 public enum NavigationTransition
 {
-	Default,
-	Slide,
-	DrillIn,
-	Entrance,
-	Suppress,
+    Default,
+    Slide,
+    DrillIn,
+    Entrance,
+    Suppress,
 }

--- a/src/AppTemplate.Core/Services/INavigationService.cs
+++ b/src/AppTemplate.Core/Services/INavigationService.cs
@@ -4,17 +4,17 @@ namespace AppTemplate.Core.Services;
 
 public interface INavigationService
 {
-	bool CanGoBack { get; }
+    bool CanGoBack { get; }
 
-	NavigationSection? CurrentSection { get; }
+    NavigationSection? CurrentSection { get; }
 
-	void Initialize();
+    void Initialize();
 
-	void Navigate<TViewModel>();
+    void Navigate<TViewModel>();
 
-	void Navigate<TViewModel>(object? parameter);
+    void Navigate<TViewModel>(object? parameter);
 
-	bool GoBack();
+    bool GoBack();
 
-	void ClearBackStack();
+    void ClearBackStack();
 }

--- a/src/AppTemplate.Core/ViewModels/ViewModelBase.cs
+++ b/src/AppTemplate.Core/ViewModels/ViewModelBase.cs
@@ -2,21 +2,21 @@ namespace AppTemplate.Core.ViewModels;
 
 public abstract partial class ViewModelBase : ObservableObject
 {
-	[ObservableProperty]
-	public partial bool IsLoading { get; set; }
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
 
-	[ObservableProperty]
-	public partial string? PageTitle { get; set; }
+    [ObservableProperty]
+    public partial string? PageTitle { get; set; }
 
-	public virtual void ViewCreated() { }
+    public virtual void ViewCreated() { }
 
-	public virtual void ViewLoading() { }
+    public virtual void ViewLoading() { }
 
-	public virtual void ViewLoaded() { }
+    public virtual void ViewLoaded() { }
 
-	public virtual void ViewUnloaded() { }
+    public virtual void ViewUnloaded() { }
 
-	public virtual void OnNavigatedTo(object? parameter) { }
+    public virtual void OnNavigatedTo(object? parameter) { }
 
-	public virtual void OnNavigatedFrom() { }
+    public virtual void OnNavigatedFrom() { }
 }

--- a/src/AppTemplate.Core/ViewModels/WindowShellViewModel.cs
+++ b/src/AppTemplate.Core/ViewModels/WindowShellViewModel.cs
@@ -4,30 +4,30 @@ namespace AppTemplate.Core.ViewModels;
 
 public partial class WindowShellViewModel : ObservableObject
 {
-	private readonly INavigationService _navigationService;
+    private readonly INavigationService _navigationService;
 
-	public WindowShellViewModel(INavigationService navigationService)
-	{
-		_navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
-	}
+    public WindowShellViewModel(INavigationService navigationService)
+    {
+        _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
+    }
 
-	[ObservableProperty]
-	public partial string Title { get; set; } = "";
+    [ObservableProperty]
+    public partial string Title { get; set; } = "";
 
-	[ObservableProperty]
-	public partial bool IsLoading { get; set; }
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
 
-	[ObservableProperty]
-	public partial string LoadingStatusMessage { get; set; } = "";
+    [ObservableProperty]
+    public partial string LoadingStatusMessage { get; set; } = "";
 
-	public bool CanGoBack => _navigationService.CanGoBack;
+    public bool CanGoBack => _navigationService.CanGoBack;
 
-	public void NotifyCanGoBackChanged() => OnPropertyChanged(nameof(CanGoBack));
+    public void NotifyCanGoBackChanged() => OnPropertyChanged(nameof(CanGoBack));
 
-	[RelayCommand]
-	public void GoBack()
-	{
-		_navigationService.GoBack();
-		NotifyCanGoBackChanged();
-	}
+    [RelayCommand]
+    public void GoBack()
+    {
+        _navigationService.GoBack();
+        NotifyCanGoBackChanged();
+    }
 }

--- a/src/AppTemplate/App.xaml.cs
+++ b/src/AppTemplate/App.xaml.cs
@@ -13,115 +13,115 @@ namespace AppTemplate;
 
 public partial class App : Application, IApplication
 {
-	public static new App Current => (App)Application.Current;
+    public static new App Current => (App)Application.Current;
 
-	public IServiceProvider Services => Host!.Services;
+    public IServiceProvider Services => Host!.Services;
 
-	public App()
-	{
-		this.InitializeComponent();
-	}
+    public App()
+    {
+        this.InitializeComponent();
+    }
 
-	protected Window? MainWindow { get; private set; }
-	protected IHost? Host { get; private set; }
+    protected Window? MainWindow { get; private set; }
+    protected IHost? Host { get; private set; }
 
-	protected override async void OnLaunched(LaunchActivatedEventArgs args)
-	{
-		var builder = this.CreateBuilder(args)
-			.Configure(host => host
+    protected override async void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        var builder = this.CreateBuilder(args)
+            .Configure(host => host
 #if DEBUG
-				.UseEnvironment(Environments.Development)
+                .UseEnvironment(Environments.Development)
 #endif
-				.UseLogging(ConfigureLogging, enableUnoLogging: true)
-				.UseConfiguration(configure: configBuilder =>
-					configBuilder
-						.EmbeddedSource<App>()
-						.Section<AppConfig>()
-				)
-				.UseLocalization()
-				.UseDefaultServiceProvider((context, options) =>
-				{
-					options.ValidateScopes = true;
-					options.ValidateOnBuild = true;
-				})
-				.UseHttp((context, services) =>
-				{
+                .UseLogging(ConfigureLogging, enableUnoLogging: true)
+                .UseConfiguration(configure: configBuilder =>
+                    configBuilder
+                        .EmbeddedSource<App>()
+                        .Section<AppConfig>()
+                )
+                .UseLocalization()
+                .UseDefaultServiceProvider((context, options) =>
+                {
+                    options.ValidateScopes = true;
+                    options.ValidateOnBuild = true;
+                })
+                .UseHttp((context, services) =>
+                {
 #if DEBUG
-					services.AddTransient<DelegatingHandler, DebugHttpHandler>();
+                    services.AddTransient<DelegatingHandler, DebugHttpHandler>();
 #endif
-				})
-				.ConfigureServices(RegisterServices)
-			);
+                })
+                .ConfigureServices(RegisterServices)
+            );
 
-		MainWindow = builder.Window;
+        MainWindow = builder.Window;
 
 #if DEBUG
-		MainWindow.UseStudio();
+        MainWindow.UseStudio();
 #endif
-		MainWindow.SetWindowIcon();
+        MainWindow.SetWindowIcon();
 
-		Host = builder.Build();
-		IoC.SetProvider(Host.Services);
+        Host = builder.Build();
+        IoC.SetProvider(Host.Services);
 
-		// Run app lifecycle updates
-		var appPreferences = Host.Services.GetRequiredService<IAppPreferences>();
-		var appUpdater = Host.Services.GetRequiredService<IAppUpdater>();
-		await appUpdater.EnsureAppUpToDateAsync();
-		appPreferences.LaunchCount++;
+        // Run app lifecycle updates
+        var appPreferences = Host.Services.GetRequiredService<IAppPreferences>();
+        var appUpdater = Host.Services.GetRequiredService<IAppUpdater>();
+        await appUpdater.EnsureAppUpToDateAsync();
+        appPreferences.LaunchCount++;
 
-		// Create WindowShell as root content
-		if (MainWindow.Content is not WindowShell)
-		{
-			var shell = new WindowShell(Host.Services, MainWindow);
-			MainWindow.Content = shell;
-		}
+        // Create WindowShell as root content
+        if (MainWindow.Content is not WindowShell)
+        {
+            var shell = new WindowShell(Host.Services, MainWindow);
+            MainWindow.Content = shell;
+        }
 
-		MainWindow.Activate();
-	}
+        MainWindow.Activate();
+    }
 
-	private static void RegisterServices(HostBuilderContext context, IServiceCollection services)
-	{
-		// Singleton services
-		services.AddSingleton<IApplication>(sp => Current);
-		services.AddSingleton<IPreferences, Preferences>();
-		services.AddSingleton<IAppPreferences, AppPreferences>();
-		services.AddSingleton<IDisplayRequestManager, DisplayRequestManager>();
-		services.AddSingleton<IAppUpdater, Infrastructure.AppUpdater>();
-		services.AddScoped<IAppRatingService, AppRatingService>();
+    private static void RegisterServices(HostBuilderContext context, IServiceCollection services)
+    {
+        // Singleton services
+        services.AddSingleton<IApplication>(sp => Current);
+        services.AddSingleton<IPreferences, Preferences>();
+        services.AddSingleton<IAppPreferences, AppPreferences>();
+        services.AddSingleton<IDisplayRequestManager, DisplayRequestManager>();
+        services.AddSingleton<IAppUpdater, Infrastructure.AppUpdater>();
+        services.AddScoped<IAppRatingService, AppRatingService>();
 
-		// Per-window scoped services
-		services.AddScoped<IThemeManager, ThemeManager>();
-		services.AddScoped<WindowShellProvider>();
-		services.AddScoped<IWindowShellProvider>(sp => sp.GetRequiredService<WindowShellProvider>());
-		services.AddScoped<IXamlRootProvider>(sp => sp.GetRequiredService<WindowShellProvider>());
-		services.AddScoped<IDialogCoordinator, DialogCoordinator>();
-		services.AddScoped<IDialogService, DialogService>();
-		services.AddScoped<IConfirmationDialogService, ConfirmationDialogService>();
-		services.AddScoped<ILauncherService, LauncherService>();
-		services.AddScoped<IShareService, ShareService>();
-		services.AddScoped<INavigationService>(sp =>
-		{
-			var service = new NavigationService(sp.GetRequiredService<IWindowShellProvider>());
-			service.RegisterView(typeof(Views.MainView), typeof(MainViewModel));
-			service.RegisterView(typeof(Views.SettingsView), typeof(SettingsViewModel));
-			return service;
-		});
+        // Per-window scoped services
+        services.AddScoped<IThemeManager, ThemeManager>();
+        services.AddScoped<WindowShellProvider>();
+        services.AddScoped<IWindowShellProvider>(sp => sp.GetRequiredService<WindowShellProvider>());
+        services.AddScoped<IXamlRootProvider>(sp => sp.GetRequiredService<WindowShellProvider>());
+        services.AddScoped<IDialogCoordinator, DialogCoordinator>();
+        services.AddScoped<IDialogService, DialogService>();
+        services.AddScoped<IConfirmationDialogService, ConfirmationDialogService>();
+        services.AddScoped<ILauncherService, LauncherService>();
+        services.AddScoped<IShareService, ShareService>();
+        services.AddScoped<INavigationService>(sp =>
+        {
+            var service = new NavigationService(sp.GetRequiredService<IWindowShellProvider>());
+            service.RegisterView(typeof(Views.MainView), typeof(MainViewModel));
+            service.RegisterView(typeof(Views.SettingsView), typeof(SettingsViewModel));
+            return service;
+        });
 
-		// Scoped ViewModels
-		services.AddScoped<WindowShellViewModel>();
+        // Scoped ViewModels
+        services.AddScoped<WindowShellViewModel>();
 
-		// Transient ViewModels (new instance per navigation)
-		services.AddTransient<MainViewModel>();
-		services.AddTransient<SettingsViewModel>();
-	}
+        // Transient ViewModels (new instance per navigation)
+        services.AddTransient<MainViewModel>();
+        services.AddTransient<SettingsViewModel>();
+    }
 
-	private static void ConfigureLogging(HostBuilderContext context, ILoggingBuilder logBuilder)
-	{
-		logBuilder
-			.SetMinimumLevel(
-				context.HostingEnvironment.IsDevelopment() ?
-					LogLevel.Information :
-					LogLevel.Warning)
-			.CoreLogLevel(LogLevel.Warning);
-	}
+    private static void ConfigureLogging(HostBuilderContext context, ILoggingBuilder logBuilder)
+    {
+        logBuilder
+            .SetMinimumLevel(
+                context.HostingEnvironment.IsDevelopment() ?
+                    LogLevel.Information :
+                    LogLevel.Warning)
+            .CoreLogLevel(LogLevel.Warning);
+    }
 }

--- a/src/AppTemplate/Converters/EnumLocalizationConverter.cs
+++ b/src/AppTemplate/Converters/EnumLocalizationConverter.cs
@@ -5,19 +5,19 @@ namespace AppTemplate.Converters;
 
 public sealed class EnumLocalizationConverter : IValueConverter
 {
-	public object Convert(object value, Type targetType, object parameter, string language)
-	{
-		if (value is Enum enumValue)
-		{
-			var enumType = enumValue.GetType();
-			var enumName = Enum.GetName(enumType, enumValue);
-			var key = $"{enumType.Name}_{enumName}";
-			return Localizer.Instance.GetString(key);
-		}
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is Enum enumValue)
+        {
+            var enumType = enumValue.GetType();
+            var enumName = Enum.GetName(enumType, enumValue);
+            var key = $"{enumType.Name}_{enumName}";
+            return Localizer.Instance.GetString(key);
+        }
 
-		return string.Empty;
-	}
+        return string.Empty;
+    }
 
-	public object ConvertBack(object value, Type targetType, object parameter, string language)
-		=> throw new NotSupportedException();
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotSupportedException();
 }

--- a/src/AppTemplate/Converters/NullToVisibilityConverter.cs
+++ b/src/AppTemplate/Converters/NullToVisibilityConverter.cs
@@ -5,14 +5,14 @@ namespace AppTemplate.Converters;
 
 public sealed class NullToVisibilityConverter
 {
-	public bool Invert { get; set; }
+    public bool Invert { get; set; }
 
-	public object Convert(object value, Type targetType, object parameter, string language)
-	{
-		var shouldShow = Invert ? value is null : value is not null;
-		return shouldShow ? Visibility.Visible : Visibility.Collapsed;
-	}
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        var shouldShow = Invert ? value is null : value is not null;
+        return shouldShow ? Visibility.Visible : Visibility.Collapsed;
+    }
 
-	public object ConvertBack(object value, Type targetType, object parameter, string language)
-		=> throw new NotSupportedException();
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotSupportedException();
 }

--- a/src/AppTemplate/Infrastructure/AppUpdater.cs
+++ b/src/AppTemplate/Infrastructure/AppUpdater.cs
@@ -5,61 +5,61 @@ namespace AppTemplate.Infrastructure;
 
 public sealed class AppUpdater : IAppUpdater
 {
-	private readonly IAppPreferences _preferences;
-	private readonly ILogger<AppUpdater> _logger;
+    private readonly IAppPreferences _preferences;
+    private readonly ILogger<AppUpdater> _logger;
 
-	public AppUpdater(IAppPreferences preferences, ILogger<AppUpdater> logger)
-	{
-		_preferences = preferences;
-		_logger = logger;
-	}
+    public AppUpdater(IAppPreferences preferences, ILogger<AppUpdater> logger)
+    {
+        _preferences = preferences;
+        _logger = logger;
+    }
 
-	public async Task EnsureAppUpToDateAsync()
-	{
-		if (_preferences.LaunchCount == 0)
-		{
-			// Fresh install — set to current version
-			_preferences.DataVersion = ApplicationReleaseInfo.DataVersion;
-			return;
-		}
+    public async Task EnsureAppUpToDateAsync()
+    {
+        if (_preferences.LaunchCount == 0)
+        {
+            // Fresh install — set to current version
+            _preferences.DataVersion = ApplicationReleaseInfo.DataVersion;
+            return;
+        }
 
-		var retryCount = 0;
-		while (_preferences.DataVersion < ApplicationReleaseInfo.DataVersion)
-		{
-			var versionBefore = _preferences.DataVersion;
+        var retryCount = 0;
+        while (_preferences.DataVersion < ApplicationReleaseInfo.DataVersion)
+        {
+            var versionBefore = _preferences.DataVersion;
 
-			switch (_preferences.DataVersion)
-			{
-				case 0:
-					await MigrateFromVersion0ToVersion1Async();
-					break;
-				// Add future migration cases here:
-				// case 1:
-				//     await MigrateFromVersion1ToVersion2Async();
-				//     break;
-			}
+            switch (_preferences.DataVersion)
+            {
+                case 0:
+                    await MigrateFromVersion0ToVersion1Async();
+                    break;
+                    // Add future migration cases here:
+                    // case 1:
+                    //     await MigrateFromVersion1ToVersion2Async();
+                    //     break;
+            }
 
-			if (_preferences.DataVersion == versionBefore)
-			{
-				retryCount++;
-				if (retryCount >= 3)
-				{
-					_logger.LogError("Data migration stuck at version {Version}. Forcing to current.", versionBefore);
-					_preferences.DataVersion = ApplicationReleaseInfo.DataVersion;
-					break;
-				}
-			}
-			else
-			{
-				retryCount = 0;
-			}
-		}
-	}
+            if (_preferences.DataVersion == versionBefore)
+            {
+                retryCount++;
+                if (retryCount >= 3)
+                {
+                    _logger.LogError("Data migration stuck at version {Version}. Forcing to current.", versionBefore);
+                    _preferences.DataVersion = ApplicationReleaseInfo.DataVersion;
+                    break;
+                }
+            }
+            else
+            {
+                retryCount = 0;
+            }
+        }
+    }
 
-	private Task MigrateFromVersion0ToVersion1Async()
-	{
-		// Add migration logic here
-		_preferences.DataVersion = 1;
-		return Task.CompletedTask;
-	}
+    private Task MigrateFromVersion0ToVersion1Async()
+    {
+        // Add migration logic here
+        _preferences.DataVersion = 1;
+        return Task.CompletedTask;
+    }
 }

--- a/src/AppTemplate/Infrastructure/IWindowShell.cs
+++ b/src/AppTemplate/Infrastructure/IWindowShell.cs
@@ -5,15 +5,15 @@ namespace AppTemplate.Infrastructure;
 
 public interface IWindowShell
 {
-	WindowShellViewModel ViewModel { get; }
+    WindowShellViewModel ViewModel { get; }
 
-	XamlRoot? XamlRoot { get; }
+    XamlRoot? XamlRoot { get; }
 
-	IServiceProvider ServiceProvider { get; }
+    IServiceProvider ServiceProvider { get; }
 
-	DispatcherQueue DispatcherQueue { get; }
+    DispatcherQueue DispatcherQueue { get; }
 
-	Frame RootFrame { get; }
+    Frame RootFrame { get; }
 
-	void SetTitleBar(UIElement? titleBar);
+    void SetTitleBar(UIElement? titleBar);
 }

--- a/src/AppTemplate/Markup/LocalizeExtension.cs
+++ b/src/AppTemplate/Markup/LocalizeExtension.cs
@@ -6,15 +6,15 @@ namespace AppTemplate.Markup;
 [MarkupExtensionReturnType(ReturnType = typeof(string))]
 public sealed class LocalizeExtension : MarkupExtension
 {
-	public string Key { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
 
-	protected override object ProvideValue()
-	{
-		if (string.IsNullOrEmpty(Key))
-		{
-			return string.Empty;
-		}
+    protected override object ProvideValue()
+    {
+        if (string.IsNullOrEmpty(Key))
+        {
+            return string.Empty;
+        }
 
-		return Localizer.Instance.GetString(Key);
-	}
+        return Localizer.Instance.GetString(Key);
+    }
 }

--- a/src/AppTemplate/Services/Dialogs/ConfirmationDialogService.cs
+++ b/src/AppTemplate/Services/Dialogs/ConfirmationDialogService.cs
@@ -5,28 +5,28 @@ namespace AppTemplate.Services.Dialogs;
 
 public sealed class ConfirmationDialogService : IConfirmationDialogService
 {
-	private readonly IDialogCoordinator _dialogCoordinator;
-	private readonly IXamlRootProvider _xamlRootProvider;
+    private readonly IDialogCoordinator _dialogCoordinator;
+    private readonly IXamlRootProvider _xamlRootProvider;
 
-	public ConfirmationDialogService(IDialogCoordinator dialogCoordinator, IXamlRootProvider xamlRootProvider)
-	{
-		_dialogCoordinator = dialogCoordinator ?? throw new ArgumentNullException(nameof(dialogCoordinator));
-		_xamlRootProvider = xamlRootProvider ?? throw new ArgumentNullException(nameof(xamlRootProvider));
-	}
+    public ConfirmationDialogService(IDialogCoordinator dialogCoordinator, IXamlRootProvider xamlRootProvider)
+    {
+        _dialogCoordinator = dialogCoordinator ?? throw new ArgumentNullException(nameof(dialogCoordinator));
+        _xamlRootProvider = xamlRootProvider ?? throw new ArgumentNullException(nameof(xamlRootProvider));
+    }
 
-	public async Task<ConfirmationResult> ShowAsync(string title, string text)
-	{
-		var dialog = new ContentDialog
-		{
-			Title = title,
-			Content = text,
-			PrimaryButtonText = Localizer.Instance.GetString("Yes"),
-			SecondaryButtonText = Localizer.Instance.GetString("No"),
-			DefaultButton = ContentDialogButton.Secondary,
-			XamlRoot = _xamlRootProvider.XamlRoot,
-		};
+    public async Task<ConfirmationResult> ShowAsync(string title, string text)
+    {
+        var dialog = new ContentDialog
+        {
+            Title = title,
+            Content = text,
+            PrimaryButtonText = Localizer.Instance.GetString("Yes"),
+            SecondaryButtonText = Localizer.Instance.GetString("No"),
+            DefaultButton = ContentDialogButton.Secondary,
+            XamlRoot = _xamlRootProvider.XamlRoot,
+        };
 
-		var result = await _dialogCoordinator.ShowAsync(dialog);
-		return result == ContentDialogResult.Primary ? ConfirmationResult.Confirmed : ConfirmationResult.Denied;
-	}
+        var result = await _dialogCoordinator.ShowAsync(dialog);
+        return result == ContentDialogResult.Primary ? ConfirmationResult.Confirmed : ConfirmationResult.Denied;
+    }
 }

--- a/src/AppTemplate/Services/Dialogs/ConfirmationResult.cs
+++ b/src/AppTemplate/Services/Dialogs/ConfirmationResult.cs
@@ -2,6 +2,6 @@ namespace AppTemplate.Services.Dialogs;
 
 public enum ConfirmationResult
 {
-	Confirmed,
-	Denied,
+    Confirmed,
+    Denied,
 }

--- a/src/AppTemplate/Services/Dialogs/DialogCoordinator.cs
+++ b/src/AppTemplate/Services/Dialogs/DialogCoordinator.cs
@@ -2,51 +2,51 @@ namespace AppTemplate.Services.Dialogs;
 
 public sealed class DialogCoordinator : IDialogCoordinator
 {
-	private readonly Queue<QueuedDialog> _dialogQueue = new();
-	private bool _isShowingDialog;
+    private readonly Queue<QueuedDialog> _dialogQueue = new();
+    private bool _isShowingDialog;
 
-	public async Task<ContentDialogResult> ShowAsync(ContentDialog dialog)
-	{
-		var queuedDialog = new QueuedDialog(dialog);
-		_dialogQueue.Enqueue(queuedDialog);
-		await ProcessQueueAsync();
-		return await queuedDialog.CompletionSource.Task;
-	}
+    public async Task<ContentDialogResult> ShowAsync(ContentDialog dialog)
+    {
+        var queuedDialog = new QueuedDialog(dialog);
+        _dialogQueue.Enqueue(queuedDialog);
+        await ProcessQueueAsync();
+        return await queuedDialog.CompletionSource.Task;
+    }
 
-	private async Task ProcessQueueAsync()
-	{
-		if (_isShowingDialog)
-		{
-			return;
-		}
+    private async Task ProcessQueueAsync()
+    {
+        if (_isShowingDialog)
+        {
+            return;
+        }
 
-		_isShowingDialog = true;
-		while (_dialogQueue.Count > 0)
-		{
-			var queued = _dialogQueue.Dequeue();
-			try
-			{
-				var result = await queued.Dialog.ShowAsync();
-				queued.CompletionSource.SetResult(result);
-			}
-			catch (Exception ex)
-			{
-				queued.CompletionSource.SetException(ex);
-			}
-		}
+        _isShowingDialog = true;
+        while (_dialogQueue.Count > 0)
+        {
+            var queued = _dialogQueue.Dequeue();
+            try
+            {
+                var result = await queued.Dialog.ShowAsync();
+                queued.CompletionSource.SetResult(result);
+            }
+            catch (Exception ex)
+            {
+                queued.CompletionSource.SetException(ex);
+            }
+        }
 
-		_isShowingDialog = false;
-	}
+        _isShowingDialog = false;
+    }
 
-	private sealed class QueuedDialog
-	{
-		public QueuedDialog(ContentDialog dialog)
-		{
-			Dialog = dialog;
-		}
+    private sealed class QueuedDialog
+    {
+        public QueuedDialog(ContentDialog dialog)
+        {
+            Dialog = dialog;
+        }
 
-		public TaskCompletionSource<ContentDialogResult> CompletionSource { get; } = new();
+        public TaskCompletionSource<ContentDialogResult> CompletionSource { get; } = new();
 
-		public ContentDialog Dialog { get; }
-	}
+        public ContentDialog Dialog { get; }
+    }
 }

--- a/src/AppTemplate/Services/Dialogs/DialogService.cs
+++ b/src/AppTemplate/Services/Dialogs/DialogService.cs
@@ -5,34 +5,34 @@ namespace AppTemplate.Services.Dialogs;
 
 public sealed class DialogService : IDialogService
 {
-	private readonly IDialogCoordinator _dialogCoordinator;
-	private readonly IXamlRootProvider _xamlRootProvider;
+    private readonly IDialogCoordinator _dialogCoordinator;
+    private readonly IXamlRootProvider _xamlRootProvider;
 
-	public DialogService(IDialogCoordinator dialogCoordinator, IXamlRootProvider xamlRootProvider)
-	{
-		_dialogCoordinator = dialogCoordinator ?? throw new ArgumentNullException(nameof(dialogCoordinator));
-		_xamlRootProvider = xamlRootProvider ?? throw new ArgumentNullException(nameof(xamlRootProvider));
-	}
+    public DialogService(IDialogCoordinator dialogCoordinator, IXamlRootProvider xamlRootProvider)
+    {
+        _dialogCoordinator = dialogCoordinator ?? throw new ArgumentNullException(nameof(dialogCoordinator));
+        _xamlRootProvider = xamlRootProvider ?? throw new ArgumentNullException(nameof(xamlRootProvider));
+    }
 
-	public async Task<ContentDialogResult> ShowAsync(string title, string content)
-	{
-		var dialog = new ContentDialog
-		{
-			Title = title,
-			Content = content,
-			PrimaryButtonText = Localizer.Instance.GetString("Ok"),
-			XamlRoot = _xamlRootProvider.XamlRoot,
-		};
-		return await _dialogCoordinator.ShowAsync(dialog);
-	}
+    public async Task<ContentDialogResult> ShowAsync(string title, string content)
+    {
+        var dialog = new ContentDialog
+        {
+            Title = title,
+            Content = content,
+            PrimaryButtonText = Localizer.Instance.GetString("Ok"),
+            XamlRoot = _xamlRootProvider.XamlRoot,
+        };
+        return await _dialogCoordinator.ShowAsync(dialog);
+    }
 
-	public async Task<ContentDialogResult> ShowAsync(ContentDialog contentDialog)
-	{
-		if (contentDialog.XamlRoot is null)
-		{
-			contentDialog.XamlRoot = _xamlRootProvider.XamlRoot;
-		}
+    public async Task<ContentDialogResult> ShowAsync(ContentDialog contentDialog)
+    {
+        if (contentDialog.XamlRoot is null)
+        {
+            contentDialog.XamlRoot = _xamlRootProvider.XamlRoot;
+        }
 
-		return await _dialogCoordinator.ShowAsync(contentDialog);
-	}
+        return await _dialogCoordinator.ShowAsync(contentDialog);
+    }
 }

--- a/src/AppTemplate/Services/Dialogs/IConfirmationDialogService.cs
+++ b/src/AppTemplate/Services/Dialogs/IConfirmationDialogService.cs
@@ -2,5 +2,5 @@ namespace AppTemplate.Services.Dialogs;
 
 public interface IConfirmationDialogService
 {
-	Task<ConfirmationResult> ShowAsync(string title, string text);
+    Task<ConfirmationResult> ShowAsync(string title, string text);
 }

--- a/src/AppTemplate/Services/Dialogs/IDialogCoordinator.cs
+++ b/src/AppTemplate/Services/Dialogs/IDialogCoordinator.cs
@@ -2,5 +2,5 @@ namespace AppTemplate.Services.Dialogs;
 
 public interface IDialogCoordinator
 {
-	Task<ContentDialogResult> ShowAsync(ContentDialog dialog);
+    Task<ContentDialogResult> ShowAsync(ContentDialog dialog);
 }

--- a/src/AppTemplate/Services/Dialogs/IDialogService.cs
+++ b/src/AppTemplate/Services/Dialogs/IDialogService.cs
@@ -2,7 +2,7 @@ namespace AppTemplate.Services.Dialogs;
 
 public interface IDialogService
 {
-	Task<ContentDialogResult> ShowAsync(string title, string content);
+    Task<ContentDialogResult> ShowAsync(string title, string content);
 
-	Task<ContentDialogResult> ShowAsync(ContentDialog contentDialog);
+    Task<ContentDialogResult> ShowAsync(ContentDialog contentDialog);
 }

--- a/src/AppTemplate/Services/DisplayRequestManager.cs
+++ b/src/AppTemplate/Services/DisplayRequestManager.cs
@@ -5,35 +5,35 @@ namespace AppTemplate.Services;
 
 internal sealed class DisplayRequestManager : IDisplayRequestManager
 {
-	private int _activeRequestCount;
-	private int _generation;
-	private readonly DisplayRequest _displayRequest = new();
+    private int _activeRequestCount;
+    private int _generation;
+    private readonly DisplayRequest _displayRequest = new();
 
-	public IDisposable RequestActive()
-	{
-		var currentGeneration = _generation;
-		_activeRequestCount++;
-		_displayRequest.RequestActive();
+    public IDisposable RequestActive()
+    {
+        var currentGeneration = _generation;
+        _activeRequestCount++;
+        _displayRequest.RequestActive();
 
-		return Disposable.Create(() =>
-		{
-			// Only release if Clear() hasn't been called in between
-			if (_generation == currentGeneration)
-			{
-				_activeRequestCount--;
-				_displayRequest.RequestRelease();
-			}
-		});
-	}
+        return Disposable.Create(() =>
+        {
+            // Only release if Clear() hasn't been called in between
+            if (_generation == currentGeneration)
+            {
+                _activeRequestCount--;
+                _displayRequest.RequestRelease();
+            }
+        });
+    }
 
-	public void Clear()
-	{
-		while (_activeRequestCount > 0)
-		{
-			_displayRequest.RequestRelease();
-			_activeRequestCount--;
-		}
+    public void Clear()
+    {
+        while (_activeRequestCount > 0)
+        {
+            _displayRequest.RequestRelease();
+            _activeRequestCount--;
+        }
 
-		_generation++;
-	}
+        _generation++;
+    }
 }

--- a/src/AppTemplate/Services/Http/DebugHttpHandler.cs
+++ b/src/AppTemplate/Services/Http/DebugHttpHandler.cs
@@ -23,7 +23,7 @@ internal class DebugHttpHandler : DelegatingHandler
             {
                 _logger.LogDebugMessage($"{request.RequestUri} ({request.Method})");
             }
-            
+
             foreach ((var key, var values) in request.Headers.ToDictionary(x => x.Key, x => string.Join(", ", x.Value)))
             {
                 _logger.LogDebugMessage($"{key}: {values}");

--- a/src/AppTemplate/Services/IDisplayRequestManager.cs
+++ b/src/AppTemplate/Services/IDisplayRequestManager.cs
@@ -2,7 +2,7 @@ namespace AppTemplate.Services;
 
 public interface IDisplayRequestManager
 {
-	IDisposable RequestActive();
+    IDisposable RequestActive();
 
-	void Clear();
+    void Clear();
 }

--- a/src/AppTemplate/Services/ILauncherService.cs
+++ b/src/AppTemplate/Services/ILauncherService.cs
@@ -2,5 +2,5 @@ namespace AppTemplate.Services;
 
 public interface ILauncherService
 {
-	Task<bool> LaunchUriAsync(Uri uri);
+    Task<bool> LaunchUriAsync(Uri uri);
 }

--- a/src/AppTemplate/Services/IShareService.cs
+++ b/src/AppTemplate/Services/IShareService.cs
@@ -2,5 +2,5 @@ namespace AppTemplate.Services;
 
 public interface IShareService
 {
-	Task ShareAsync(string title, string uri);
+    Task ShareAsync(string title, string uri);
 }

--- a/src/AppTemplate/Services/LauncherService.cs
+++ b/src/AppTemplate/Services/LauncherService.cs
@@ -2,6 +2,6 @@ namespace AppTemplate.Services;
 
 public sealed class LauncherService : ILauncherService
 {
-	public async Task<bool> LaunchUriAsync(Uri uri)
-		=> await Windows.System.Launcher.LaunchUriAsync(uri);
+    public async Task<bool> LaunchUriAsync(Uri uri)
+        => await Windows.System.Launcher.LaunchUriAsync(uri);
 }

--- a/src/AppTemplate/Services/Localization/Localizer.cs
+++ b/src/AppTemplate/Services/Localization/Localizer.cs
@@ -4,18 +4,18 @@ namespace AppTemplate.Services.Localization;
 
 public sealed class Localizer
 {
-	private static readonly Lazy<IStringLocalizer> _stringLocalizer =
-		new(() => IoC.GetRequiredService<IStringLocalizer>());
+    private static readonly Lazy<IStringLocalizer> _stringLocalizer =
+        new(() => IoC.GetRequiredService<IStringLocalizer>());
 
-	private Localizer() { }
+    private Localizer() { }
 
-	public static Localizer Instance { get; } = new();
+    public static Localizer Instance { get; } = new();
 
-	public string GetString(string key)
-	{
-		var result = _stringLocalizer.Value.GetString(key);
-		return !result.ResourceNotFound ? result.Value : $"???{key}???";
-	}
+    public string GetString(string key)
+    {
+        var result = _stringLocalizer.Value.GetString(key);
+        return !result.ResourceNotFound ? result.Value : $"???{key}???";
+    }
 
-	public string this[string key] => GetString(key);
+    public string this[string key] => GetString(key);
 }

--- a/src/AppTemplate/Services/Navigation/IWindowShellProvider.cs
+++ b/src/AppTemplate/Services/Navigation/IWindowShellProvider.cs
@@ -6,13 +6,13 @@ namespace AppTemplate.Services.Navigation;
 
 public interface IWindowShellProvider
 {
-	Window Window { get; }
+    Window Window { get; }
 
-	IWindowShell Shell { get; }
+    IWindowShell Shell { get; }
 
-	WindowShellViewModel ViewModel { get; }
+    WindowShellViewModel ViewModel { get; }
 
-	DispatcherQueue DispatcherQueue { get; }
+    DispatcherQueue DispatcherQueue { get; }
 
-	Frame RootFrame { get; }
+    Frame RootFrame { get; }
 }

--- a/src/AppTemplate/Services/Navigation/IXamlRootProvider.cs
+++ b/src/AppTemplate/Services/Navigation/IXamlRootProvider.cs
@@ -2,5 +2,5 @@ namespace AppTemplate.Services.Navigation;
 
 public interface IXamlRootProvider
 {
-	XamlRoot XamlRoot { get; }
+    XamlRoot XamlRoot { get; }
 }

--- a/src/AppTemplate/Services/Navigation/NavigationService.cs
+++ b/src/AppTemplate/Services/Navigation/NavigationService.cs
@@ -11,139 +11,139 @@ namespace AppTemplate.Services.Navigation;
 
 public sealed class NavigationService : INavigationService
 {
-	private readonly IWindowShellProvider _shellProvider;
-	private readonly Dictionary<Type, Type> _viewModelToViewMap = new();
-	private bool _initialized;
-	private bool _backRequestedSubscribed;
+    private readonly IWindowShellProvider _shellProvider;
+    private readonly Dictionary<Type, Type> _viewModelToViewMap = new();
+    private bool _initialized;
+    private bool _backRequestedSubscribed;
 
-	public NavigationService(IWindowShellProvider shellProvider)
-	{
-		_shellProvider = shellProvider;
-	}
+    public NavigationService(IWindowShellProvider shellProvider)
+    {
+        _shellProvider = shellProvider;
+    }
 
-	private Frame Frame => _shellProvider.RootFrame;
+    private Frame Frame => _shellProvider.RootFrame;
 
-	public bool CanGoBack => _initialized && Frame.CanGoBack;
+    public bool CanGoBack => _initialized && Frame.CanGoBack;
 
-	public NavigationSection? CurrentSection { get; private set; }
+    public NavigationSection? CurrentSection { get; private set; }
 
-	public void Initialize()
-	{
-		_initialized = true;
+    public void Initialize()
+    {
+        _initialized = true;
 #if HAS_UNO
 		Frame.Navigated += OnFrameNavigated;
 		UpdateBackRequestedSubscription();
 #endif
-	}
+    }
 
-	public void RegisterView(Type viewType, Type viewModelType)
-		=> _viewModelToViewMap[viewModelType] = viewType;
+    public void RegisterView(Type viewType, Type viewModelType)
+        => _viewModelToViewMap[viewModelType] = viewType;
 
-	public void Navigate<TViewModel>() => Navigate<TViewModel>(null);
+    public void Navigate<TViewModel>() => Navigate<TViewModel>(null);
 
-	public void Navigate<TViewModel>(object? parameter)
-	{
-		if (!_initialized)
-		{
-			throw new InvalidOperationException("NavigationService not initialized. Call Initialize() first.");
-		}
+    public void Navigate<TViewModel>(object? parameter)
+    {
+        if (!_initialized)
+        {
+            throw new InvalidOperationException("NavigationService not initialized. Call Initialize() first.");
+        }
 
-		if (!_viewModelToViewMap.TryGetValue(typeof(TViewModel), out var viewType))
-		{
-			throw new InvalidOperationException($"No view registered for ViewModel {typeof(TViewModel).Name}.");
-		}
+        if (!_viewModelToViewMap.TryGetValue(typeof(TViewModel), out var viewType))
+        {
+            throw new InvalidOperationException($"No view registered for ViewModel {typeof(TViewModel).Name}.");
+        }
 
-		var navInfo = GetNavigationInfo(viewType);
-		if (navInfo is not null)
-		{
-			CurrentSection = navInfo.Section;
-		}
+        var navInfo = GetNavigationInfo(viewType);
+        if (navInfo is not null)
+        {
+            CurrentSection = navInfo.Section;
+        }
 
-		var transitionInfo = GetTransitionInfo(navInfo?.Transition ?? NavigationTransition.Default, isForward: true);
-		Frame.Navigate(viewType, parameter, transitionInfo);
-
-#if HAS_UNO
-		UpdateBackRequestedSubscription();
-#endif
-	}
-
-	public bool GoBack()
-	{
-		if (!CanGoBack)
-		{
-			return false;
-		}
-
-		var backEntry = Frame.BackStack.LastOrDefault();
-		var transition = NavigationTransition.Default;
-
-		if (backEntry is not null)
-		{
-			var navInfo = GetNavigationInfo(backEntry.SourcePageType);
-			transition = navInfo?.Transition ?? NavigationTransition.Default;
-			if (navInfo is not null)
-			{
-				CurrentSection = navInfo.Section;
-			}
-		}
-
-		Frame.GoBack(GetTransitionInfo(transition, isForward: false));
+        var transitionInfo = GetTransitionInfo(navInfo?.Transition ?? NavigationTransition.Default, isForward: true);
+        Frame.Navigate(viewType, parameter, transitionInfo);
 
 #if HAS_UNO
 		UpdateBackRequestedSubscription();
 #endif
+    }
 
-		return true;
-	}
+    public bool GoBack()
+    {
+        if (!CanGoBack)
+        {
+            return false;
+        }
 
-	public void ClearBackStack()
-	{
-		Frame.BackStack.Clear();
+        var backEntry = Frame.BackStack.LastOrDefault();
+        var transition = NavigationTransition.Default;
+
+        if (backEntry is not null)
+        {
+            var navInfo = GetNavigationInfo(backEntry.SourcePageType);
+            transition = navInfo?.Transition ?? NavigationTransition.Default;
+            if (navInfo is not null)
+            {
+                CurrentSection = navInfo.Section;
+            }
+        }
+
+        Frame.GoBack(GetTransitionInfo(transition, isForward: false));
+
 #if HAS_UNO
 		UpdateBackRequestedSubscription();
 #endif
-	}
 
-	private static NavigationInfoAttribute? GetNavigationInfo(Type viewType)
-	{
-		var attr = viewType.GetCustomAttribute<NavigationInfoAttribute>();
-		if (attr is not null)
-		{
-			return attr;
-		}
+        return true;
+    }
 
-		// Walk the inheritance chain — needed because the sealed view class
-		// may inherit from an intermediate ViewBase<T> that carries the attribute.
-		var baseType = viewType.BaseType;
-		while (baseType is not null && baseType != typeof(Page))
-		{
-			attr = baseType.GetCustomAttribute<NavigationInfoAttribute>();
-			if (attr is not null)
-			{
-				return attr;
-			}
+    public void ClearBackStack()
+    {
+        Frame.BackStack.Clear();
+#if HAS_UNO
+		UpdateBackRequestedSubscription();
+#endif
+    }
 
-			baseType = baseType.BaseType;
-		}
+    private static NavigationInfoAttribute? GetNavigationInfo(Type viewType)
+    {
+        var attr = viewType.GetCustomAttribute<NavigationInfoAttribute>();
+        if (attr is not null)
+        {
+            return attr;
+        }
 
-		return null;
-	}
+        // Walk the inheritance chain — needed because the sealed view class
+        // may inherit from an intermediate ViewBase<T> that carries the attribute.
+        var baseType = viewType.BaseType;
+        while (baseType is not null && baseType != typeof(Page))
+        {
+            attr = baseType.GetCustomAttribute<NavigationInfoAttribute>();
+            if (attr is not null)
+            {
+                return attr;
+            }
 
-	private static NavigationTransitionInfo GetTransitionInfo(NavigationTransition transition, bool isForward)
-	{
-		return transition switch
-		{
-			NavigationTransition.DrillIn => new DrillInNavigationTransitionInfo(),
-			NavigationTransition.Entrance => new EntranceNavigationTransitionInfo(),
-			NavigationTransition.Suppress => new SuppressNavigationTransitionInfo(),
-			_ => new SlideNavigationTransitionInfo
-			{
-				Effect = isForward
-					? SlideNavigationTransitionEffect.FromRight
-					: SlideNavigationTransitionEffect.FromLeft,
-			},
-		};
-	}
+            baseType = baseType.BaseType;
+        }
+
+        return null;
+    }
+
+    private static NavigationTransitionInfo GetTransitionInfo(NavigationTransition transition, bool isForward)
+    {
+        return transition switch
+        {
+            NavigationTransition.DrillIn => new DrillInNavigationTransitionInfo(),
+            NavigationTransition.Entrance => new EntranceNavigationTransitionInfo(),
+            NavigationTransition.Suppress => new SuppressNavigationTransitionInfo(),
+            _ => new SlideNavigationTransitionInfo
+            {
+                Effect = isForward
+                    ? SlideNavigationTransitionEffect.FromRight
+                    : SlideNavigationTransitionEffect.FromLeft,
+            },
+        };
+    }
 
 #if HAS_UNO
 	private void OnFrameNavigated(object sender, Microsoft.UI.Xaml.Navigation.NavigationEventArgs e)

--- a/src/AppTemplate/Services/Navigation/WindowShellProvider.cs
+++ b/src/AppTemplate/Services/Navigation/WindowShellProvider.cs
@@ -7,45 +7,45 @@ namespace AppTemplate.Services.Navigation;
 
 internal sealed class WindowShellProvider : IWindowShellProvider, IXamlRootProvider
 {
-	private WindowShell? _shell;
-	private Window? _window;
-	private DispatcherQueue? _dispatcherQueue;
+    private WindowShell? _shell;
+    private Window? _window;
+    private DispatcherQueue? _dispatcherQueue;
 
-	public void SetShell(WindowShell shell, Window window)
-	{
-		_shell = shell ?? throw new ArgumentNullException(nameof(shell));
-		_window = window;
-		_dispatcherQueue = shell.DispatcherQueue;
-	}
+    public void SetShell(WindowShell shell, Window window)
+    {
+        _shell = shell ?? throw new ArgumentNullException(nameof(shell));
+        _window = window;
+        _dispatcherQueue = shell.DispatcherQueue;
+    }
 
-	public IWindowShell Shell { get { EnsureInitialized(); return _shell; } }
+    public IWindowShell Shell { get { EnsureInitialized(); return _shell; } }
 
-	public Window Window { get { EnsureInitialized(); return _window; } }
+    public Window Window { get { EnsureInitialized(); return _window; } }
 
-	public WindowShellViewModel ViewModel { get { EnsureInitialized(); return _shell.ViewModel; } }
+    public WindowShellViewModel ViewModel { get { EnsureInitialized(); return _shell.ViewModel; } }
 
-	public DispatcherQueue DispatcherQueue { get { EnsureInitialized(); return _dispatcherQueue; } }
+    public DispatcherQueue DispatcherQueue { get { EnsureInitialized(); return _dispatcherQueue; } }
 
-	public Frame RootFrame { get { EnsureInitialized(); return _shell.RootFrame; } }
+    public Frame RootFrame { get { EnsureInitialized(); return _shell.RootFrame; } }
 
-	public IServiceProvider ServiceProvider { get { EnsureInitialized(); return _shell.ServiceProvider; } }
+    public IServiceProvider ServiceProvider { get { EnsureInitialized(); return _shell.ServiceProvider; } }
 
-	public XamlRoot XamlRoot
-	{
-		get { EnsureInitialized(); return _shell.XamlRoot!; }
-		internal set { } // Set by WindowShell during Loading event
-	}
+    public XamlRoot XamlRoot
+    {
+        get { EnsureInitialized(); return _shell.XamlRoot!; }
+        internal set { } // Set by WindowShell during Loading event
+    }
 
-	internal void SetXamlRoot(XamlRoot xamlRoot) => XamlRoot = xamlRoot;
+    internal void SetXamlRoot(XamlRoot xamlRoot) => XamlRoot = xamlRoot;
 
-	[MemberNotNull(nameof(_shell))]
-	[MemberNotNull(nameof(_window))]
-	[MemberNotNull(nameof(_dispatcherQueue))]
-	private void EnsureInitialized()
-	{
-		if (_shell is null || _dispatcherQueue is null || _window is null)
-		{
-			throw new InvalidOperationException("WindowShellProvider was not initialized. Ensure WindowShell has been created.");
-		}
-	}
+    [MemberNotNull(nameof(_shell))]
+    [MemberNotNull(nameof(_window))]
+    [MemberNotNull(nameof(_dispatcherQueue))]
+    private void EnsureInitialized()
+    {
+        if (_shell is null || _dispatcherQueue is null || _window is null)
+        {
+            throw new InvalidOperationException("WindowShellProvider was not initialized. Ensure WindowShell has been created.");
+        }
+    }
 }

--- a/src/AppTemplate/Services/Rating/AppRatingService.cs
+++ b/src/AppTemplate/Services/Rating/AppRatingService.cs
@@ -6,53 +6,53 @@ namespace AppTemplate.Services.Rating;
 
 public sealed class AppRatingService : IAppRatingService
 {
-	private const int MinLaunchCountForRating = 5;
+    private const int MinLaunchCountForRating = 5;
 
-	private readonly IAppPreferences _appPreferences;
-	private readonly IConfirmationDialogService _confirmationDialogService;
-	private readonly ILauncherService _launcherService;
+    private readonly IAppPreferences _appPreferences;
+    private readonly IConfirmationDialogService _confirmationDialogService;
+    private readonly ILauncherService _launcherService;
 
-	public AppRatingService(
-		IAppPreferences appPreferences,
-		IConfirmationDialogService confirmationDialogService,
-		ILauncherService launcherService)
-	{
-		_appPreferences = appPreferences;
-		_confirmationDialogService = confirmationDialogService;
-		_launcherService = launcherService;
-	}
+    public AppRatingService(
+        IAppPreferences appPreferences,
+        IConfirmationDialogService confirmationDialogService,
+        ILauncherService launcherService)
+    {
+        _appPreferences = appPreferences;
+        _confirmationDialogService = confirmationDialogService;
+        _launcherService = launcherService;
+    }
 
-	public async Task TryPromptForRatingAsync()
-	{
-		if (!_appPreferences.OfferUserRating)
-		{
-			return;
-		}
+    public async Task TryPromptForRatingAsync()
+    {
+        if (!_appPreferences.OfferUserRating)
+        {
+            return;
+        }
 
-		if (_appPreferences.LaunchCount < MinLaunchCountForRating)
-		{
-			return;
-		}
+        if (_appPreferences.LaunchCount < MinLaunchCountForRating)
+        {
+            return;
+        }
 
-		var result = await _confirmationDialogService.ShowAsync(
-			Localizer.Instance.GetString("RateAppTitle"),
-			Localizer.Instance.GetString("RateAppMessage"));
+        var result = await _confirmationDialogService.ShowAsync(
+            Localizer.Instance.GetString("RateAppTitle"),
+            Localizer.Instance.GetString("RateAppMessage"));
 
-		if (result == ConfirmationResult.Confirmed)
-		{
-			_appPreferences.OfferUserRating = false;
-			await LaunchStoreReviewAsync();
-		}
-		else
-		{
-			// User declined — don't ask again
-			_appPreferences.OfferUserRating = false;
-		}
-	}
+        if (result == ConfirmationResult.Confirmed)
+        {
+            _appPreferences.OfferUserRating = false;
+            await LaunchStoreReviewAsync();
+        }
+        else
+        {
+            // User declined — don't ask again
+            _appPreferences.OfferUserRating = false;
+        }
+    }
 
-	private async Task LaunchStoreReviewAsync()
-	{
-		var uri = new Uri("ms-windows-store://review/?ProductId=REPLACE_WITH_STORE_ID");
-		await _launcherService.LaunchUriAsync(uri);
-	}
+    private async Task LaunchStoreReviewAsync()
+    {
+        var uri = new Uri("ms-windows-store://review/?ProductId=REPLACE_WITH_STORE_ID");
+        await _launcherService.LaunchUriAsync(uri);
+    }
 }

--- a/src/AppTemplate/Services/Rating/IAppRatingService.cs
+++ b/src/AppTemplate/Services/Rating/IAppRatingService.cs
@@ -2,5 +2,5 @@ namespace AppTemplate.Services.Rating;
 
 public interface IAppRatingService
 {
-	Task TryPromptForRatingAsync();
+    Task TryPromptForRatingAsync();
 }

--- a/src/AppTemplate/Services/Settings/AppPreferences.cs
+++ b/src/AppTemplate/Services/Settings/AppPreferences.cs
@@ -2,45 +2,45 @@ namespace AppTemplate.Services.Settings;
 
 public sealed class AppPreferences : IAppPreferences
 {
-	private readonly IPreferences _preferences;
+    private readonly IPreferences _preferences;
 
-	public AppPreferences(IPreferences preferences)
-	{
-		_preferences = preferences ?? throw new ArgumentNullException(nameof(preferences));
-	}
+    public AppPreferences(IPreferences preferences)
+    {
+        _preferences = preferences ?? throw new ArgumentNullException(nameof(preferences));
+    }
 
-	private const string DataVersionKey = "AppDataVersion";
-	public int DataVersion
-	{
-		get => _preferences.Get(DataVersionKey, 0);
-		set => _preferences.Set(DataVersionKey, value);
-	}
+    private const string DataVersionKey = "AppDataVersion";
+    public int DataVersion
+    {
+        get => _preferences.Get(DataVersionKey, 0);
+        set => _preferences.Set(DataVersionKey, value);
+    }
 
-	private const string FirstStartKey = "AppFirstStart";
-	public bool FirstStart
-	{
-		get => _preferences.Get(FirstStartKey, true);
-		set => _preferences.Set(FirstStartKey, value);
-	}
+    private const string FirstStartKey = "AppFirstStart";
+    public bool FirstStart
+    {
+        get => _preferences.Get(FirstStartKey, true);
+        set => _preferences.Set(FirstStartKey, value);
+    }
 
-	private const string LaunchCountKey = "AppLaunchCount";
-	public int LaunchCount
-	{
-		get => _preferences.Get(LaunchCountKey, 0);
-		set => _preferences.Set(LaunchCountKey, value);
-	}
+    private const string LaunchCountKey = "AppLaunchCount";
+    public int LaunchCount
+    {
+        get => _preferences.Get(LaunchCountKey, 0);
+        set => _preferences.Set(LaunchCountKey, value);
+    }
 
-	private const string OfferUserRatingKey = "OfferUserRating";
-	public bool OfferUserRating
-	{
-		get => _preferences.Get(OfferUserRatingKey, true);
-		set => _preferences.Set(OfferUserRatingKey, value);
-	}
+    private const string OfferUserRatingKey = "OfferUserRating";
+    public bool OfferUserRating
+    {
+        get => _preferences.Get(OfferUserRatingKey, true);
+        set => _preferences.Set(OfferUserRatingKey, value);
+    }
 
-	private const string ThemeKey = "AppTheme";
-	public ElementTheme Theme
-	{
-		get => _preferences.GetComplex(ThemeKey, ElementTheme.Default);
-		set => _preferences.SetComplex(ThemeKey, value);
-	}
+    private const string ThemeKey = "AppTheme";
+    public ElementTheme Theme
+    {
+        get => _preferences.GetComplex(ThemeKey, ElementTheme.Default);
+        set => _preferences.SetComplex(ThemeKey, value);
+    }
 }

--- a/src/AppTemplate/Services/Settings/IAppPreferences.cs
+++ b/src/AppTemplate/Services/Settings/IAppPreferences.cs
@@ -2,13 +2,13 @@ namespace AppTemplate.Services.Settings;
 
 public interface IAppPreferences
 {
-	int DataVersion { get; set; }
+    int DataVersion { get; set; }
 
-	bool FirstStart { get; set; }
+    bool FirstStart { get; set; }
 
-	int LaunchCount { get; set; }
+    int LaunchCount { get; set; }
 
-	bool OfferUserRating { get; set; }
+    bool OfferUserRating { get; set; }
 
-	ElementTheme Theme { get; set; }
+    ElementTheme Theme { get; set; }
 }

--- a/src/AppTemplate/Services/Settings/IPreferences.cs
+++ b/src/AppTemplate/Services/Settings/IPreferences.cs
@@ -2,17 +2,17 @@ namespace AppTemplate.Services.Settings;
 
 public interface IPreferences
 {
-	T Get<T>(string key, T defaultValue);
+    T Get<T>(string key, T defaultValue);
 
-	void Set<T>(string key, T value);
+    void Set<T>(string key, T value);
 
-	T GetComplex<T>(string key, T defaultValue);
+    T GetComplex<T>(string key, T defaultValue);
 
-	void SetComplex<T>(string key, T value);
+    void SetComplex<T>(string key, T value);
 
-	bool ContainsKey(string key);
+    bool ContainsKey(string key);
 
-	void Remove(string key);
+    void Remove(string key);
 
-	void Clear();
+    void Clear();
 }

--- a/src/AppTemplate/Services/Settings/Preferences.cs
+++ b/src/AppTemplate/Services/Settings/Preferences.cs
@@ -5,61 +5,61 @@ namespace AppTemplate.Services.Settings;
 
 public sealed class Preferences : IPreferences
 {
-	private readonly ApplicationDataContainer _container = ApplicationData.Current.LocalSettings;
+    private readonly ApplicationDataContainer _container = ApplicationData.Current.LocalSettings;
 
-	public T Get<T>(string key, T defaultValue)
-	{
-		if (_container.Values.TryGetValue(key, out var value))
-		{
-			if (value is T typed)
-			{
-				return typed;
-			}
+    public T Get<T>(string key, T defaultValue)
+    {
+        if (_container.Values.TryGetValue(key, out var value))
+        {
+            if (value is T typed)
+            {
+                return typed;
+            }
 
-			// Handle numeric type conversions (ApplicationData stores as object)
-			try
-			{
-				return (T)Convert.ChangeType(value, typeof(T));
-			}
-			catch
-			{
-				return defaultValue;
-			}
-		}
+            // Handle numeric type conversions (ApplicationData stores as object)
+            try
+            {
+                return (T)Convert.ChangeType(value, typeof(T));
+            }
+            catch
+            {
+                return defaultValue;
+            }
+        }
 
-		return defaultValue;
-	}
+        return defaultValue;
+    }
 
-	public void Set<T>(string key, T value)
-	{
-		_container.Values[key] = value;
-	}
+    public void Set<T>(string key, T value)
+    {
+        _container.Values[key] = value;
+    }
 
-	public T GetComplex<T>(string key, T defaultValue)
-	{
-		if (_container.Values.TryGetValue(key, out var value) && value is string json)
-		{
-			try
-			{
-				return JsonSerializer.Deserialize<T>(json) ?? defaultValue;
-			}
-			catch
-			{
-				return defaultValue;
-			}
-		}
+    public T GetComplex<T>(string key, T defaultValue)
+    {
+        if (_container.Values.TryGetValue(key, out var value) && value is string json)
+        {
+            try
+            {
+                return JsonSerializer.Deserialize<T>(json) ?? defaultValue;
+            }
+            catch
+            {
+                return defaultValue;
+            }
+        }
 
-		return defaultValue;
-	}
+        return defaultValue;
+    }
 
-	public void SetComplex<T>(string key, T value)
-	{
-		_container.Values[key] = JsonSerializer.Serialize(value);
-	}
+    public void SetComplex<T>(string key, T value)
+    {
+        _container.Values[key] = JsonSerializer.Serialize(value);
+    }
 
-	public bool ContainsKey(string key) => _container.Values.ContainsKey(key);
+    public bool ContainsKey(string key) => _container.Values.ContainsKey(key);
 
-	public void Remove(string key) => _container.Values.Remove(key);
+    public void Remove(string key) => _container.Values.Remove(key);
 
-	public void Clear() => _container.Values.Clear();
+    public void Clear() => _container.Values.Clear();
 }

--- a/src/AppTemplate/Services/ShareService.cs
+++ b/src/AppTemplate/Services/ShareService.cs
@@ -6,32 +6,32 @@ namespace AppTemplate.Services;
 
 public sealed class ShareService : IShareService
 {
-	private readonly IWindowShellProvider _windowShellProvider;
-	private string? _pendingTitle;
-	private string? _pendingUri;
+    private readonly IWindowShellProvider _windowShellProvider;
+    private string? _pendingTitle;
+    private string? _pendingUri;
 
-	public ShareService(IWindowShellProvider windowShellProvider)
-		=> _windowShellProvider = windowShellProvider;
+    public ShareService(IWindowShellProvider windowShellProvider)
+        => _windowShellProvider = windowShellProvider;
 
-	public Task ShareAsync(string title, string uri)
-	{
-		_pendingTitle = title;
-		_pendingUri = uri;
+    public Task ShareAsync(string title, string uri)
+    {
+        _pendingTitle = title;
+        _pendingUri = uri;
 
 #if !HAS_UNO
-		var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(_windowShellProvider.Window);
-		var interop = DataTransferManager.As<IDataTransferManagerInterop>();
-		var result = interop.GetForWindow(hwnd, _dtmIid);
-		var dtm = WinRT.MarshalInterface<DataTransferManager>.FromAbi(result);
-		dtm.DataRequested += OnDataRequested;
-		try
-		{
-			interop.ShowShareUIForWindow(hwnd);
-		}
-		catch (COMException)
-		{
-			dtm.DataRequested -= OnDataRequested;
-		}
+        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(_windowShellProvider.Window);
+        var interop = DataTransferManager.As<IDataTransferManagerInterop>();
+        var result = interop.GetForWindow(hwnd, _dtmIid);
+        var dtm = WinRT.MarshalInterface<DataTransferManager>.FromAbi(result);
+        dtm.DataRequested += OnDataRequested;
+        try
+        {
+            interop.ShowShareUIForWindow(hwnd);
+        }
+        catch (COMException)
+        {
+            dtm.DataRequested -= OnDataRequested;
+        }
 #else
 		var dtm = DataTransferManager.GetForCurrentView();
 		dtm.DataRequested += OnDataRequested;
@@ -45,35 +45,35 @@ public sealed class ShareService : IShareService
 		}
 #endif
 
-		return Task.CompletedTask;
-	}
+        return Task.CompletedTask;
+    }
 
-	private void OnDataRequested(DataTransferManager sender, DataRequestedEventArgs args)
-	{
-		sender.DataRequested -= OnDataRequested;
-		args.Request.Data.Properties.Title = _pendingTitle ?? string.Empty;
-		if (_pendingUri is not null)
-		{
-			args.Request.Data.SetWebLink(new Uri(_pendingUri));
-			args.Request.Data.SetText(_pendingUri);
-		}
+    private void OnDataRequested(DataTransferManager sender, DataRequestedEventArgs args)
+    {
+        sender.DataRequested -= OnDataRequested;
+        args.Request.Data.Properties.Title = _pendingTitle ?? string.Empty;
+        if (_pendingUri is not null)
+        {
+            args.Request.Data.SetWebLink(new Uri(_pendingUri));
+            args.Request.Data.SetText(_pendingUri);
+        }
 
-		_pendingTitle = null;
-		_pendingUri = null;
-	}
+        _pendingTitle = null;
+        _pendingUri = null;
+    }
 
 #if !HAS_UNO
-	[ComImport]
-	[Guid("3A3DCD6C-3EAB-43DC-BCDE-45671CE800C8")]
-	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-	private interface IDataTransferManagerInterop
-	{
-		IntPtr GetForWindow([In] IntPtr appWindow, [In] ref Guid riid);
+    [ComImport]
+    [Guid("3A3DCD6C-3EAB-43DC-BCDE-45671CE800C8")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IDataTransferManagerInterop
+    {
+        IntPtr GetForWindow([In] IntPtr appWindow, [In] ref Guid riid);
 
-		void ShowShareUIForWindow(IntPtr appWindow);
-	}
+        void ShowShareUIForWindow(IntPtr appWindow);
+    }
 
-	private static readonly Guid _dtmIid =
-		new(0xa5caee9b, 0x8708, 0x49d1, 0x8d, 0x36, 0x67, 0xd2, 0x5a, 0x8d, 0xa0, 0x0c);
+    private static readonly Guid _dtmIid =
+        new(0xa5caee9b, 0x8708, 0x49d1, 0x8d, 0x36, 0x67, 0xd2, 0x5a, 0x8d, 0xa0, 0x0c);
 #endif
 }

--- a/src/AppTemplate/Services/Theming/IThemeManager.cs
+++ b/src/AppTemplate/Services/Theming/IThemeManager.cs
@@ -2,9 +2,9 @@ namespace AppTemplate.Services.Theming;
 
 public interface IThemeManager : IDisposable
 {
-	void SetTheme(ElementTheme theme);
+    void SetTheme(ElementTheme theme);
 
-	ElementTheme CurrentTheme { get; }
+    ElementTheme CurrentTheme { get; }
 
-	ApplicationTheme ActualTheme { get; }
+    ApplicationTheme ActualTheme { get; }
 }

--- a/src/AppTemplate/Services/Theming/ThemeManager.cs
+++ b/src/AppTemplate/Services/Theming/ThemeManager.cs
@@ -7,80 +7,80 @@ namespace AppTemplate.Services.Theming;
 
 public sealed class ThemeManager : IThemeManager
 {
-	private readonly IWindowShellProvider _windowShellProvider;
-	private readonly UISettings _uiSettings = new();
+    private readonly IWindowShellProvider _windowShellProvider;
+    private readonly UISettings _uiSettings = new();
 
-	public ThemeManager(IWindowShellProvider windowShellProvider)
-	{
-		_windowShellProvider = windowShellProvider;
-		_uiSettings.ColorValuesChanged += OnColorValuesChanged;
-	}
+    public ThemeManager(IWindowShellProvider windowShellProvider)
+    {
+        _windowShellProvider = windowShellProvider;
+        _uiSettings.ColorValuesChanged += OnColorValuesChanged;
+    }
 
-	public void SetTheme(ElementTheme theme)
-	{
-		GetRootElement().RequestedTheme = theme;
-		UpdateTitleBarTheming();
-	}
+    public void SetTheme(ElementTheme theme)
+    {
+        GetRootElement().RequestedTheme = theme;
+        UpdateTitleBarTheming();
+    }
 
-	public ElementTheme CurrentTheme => GetRootElement().RequestedTheme;
+    public ElementTheme CurrentTheme => GetRootElement().RequestedTheme;
 
-	public ApplicationTheme ActualTheme => CurrentTheme switch
-	{
-		ElementTheme.Default => Application.Current.RequestedTheme,
-		ElementTheme.Light => ApplicationTheme.Light,
-		ElementTheme.Dark => ApplicationTheme.Dark,
-		_ => throw new ArgumentOutOfRangeException(),
-	};
+    public ApplicationTheme ActualTheme => CurrentTheme switch
+    {
+        ElementTheme.Default => Application.Current.RequestedTheme,
+        ElementTheme.Light => ApplicationTheme.Light,
+        ElementTheme.Dark => ApplicationTheme.Dark,
+        _ => throw new ArgumentOutOfRangeException(),
+    };
 
-	private FrameworkElement GetRootElement()
-	{
-		return _windowShellProvider.Shell as FrameworkElement
-			?? throw new InvalidOperationException("Root element of the window is not a FrameworkElement.");
-	}
+    private FrameworkElement GetRootElement()
+    {
+        return _windowShellProvider.Shell as FrameworkElement
+            ?? throw new InvalidOperationException("Root element of the window is not a FrameworkElement.");
+    }
 
-	private void UpdateTitleBarTheming()
-	{
+    private void UpdateTitleBarTheming()
+    {
 #if !HAS_UNO
-		try
-		{
-			var titleBar = _windowShellProvider.Window.AppWindow.TitleBar;
-			titleBar.BackgroundColor = Colors.Transparent;
-			titleBar.ButtonBackgroundColor = Colors.Transparent;
-			titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
+        try
+        {
+            var titleBar = _windowShellProvider.Window.AppWindow.TitleBar;
+            titleBar.BackgroundColor = Colors.Transparent;
+            titleBar.ButtonBackgroundColor = Colors.Transparent;
+            titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
 
-			if (ActualTheme == ApplicationTheme.Dark)
-			{
-				titleBar.ButtonForegroundColor = Colors.White;
-				titleBar.ButtonInactiveForegroundColor = Colors.Gray;
-				titleBar.ButtonHoverBackgroundColor = Color.FromArgb(100, 100, 100, 100);
-				titleBar.ButtonHoverForegroundColor = Colors.White;
-				titleBar.ButtonPressedBackgroundColor = Color.FromArgb(200, 100, 100, 100);
-				titleBar.ButtonPressedForegroundColor = Colors.White;
-			}
-			else
-			{
-				titleBar.ButtonForegroundColor = Colors.Black;
-				titleBar.ButtonInactiveForegroundColor = Colors.Gray;
-				titleBar.ButtonHoverBackgroundColor = Color.FromArgb(100, 200, 200, 200);
-				titleBar.ButtonHoverForegroundColor = Colors.Black;
-				titleBar.ButtonPressedBackgroundColor = Color.FromArgb(200, 200, 200, 200);
-				titleBar.ButtonPressedForegroundColor = Colors.Black;
-			}
-		}
-		catch
-		{
-			// Title bar customization not supported on this platform
-		}
+            if (ActualTheme == ApplicationTheme.Dark)
+            {
+                titleBar.ButtonForegroundColor = Colors.White;
+                titleBar.ButtonInactiveForegroundColor = Colors.Gray;
+                titleBar.ButtonHoverBackgroundColor = Color.FromArgb(100, 100, 100, 100);
+                titleBar.ButtonHoverForegroundColor = Colors.White;
+                titleBar.ButtonPressedBackgroundColor = Color.FromArgb(200, 100, 100, 100);
+                titleBar.ButtonPressedForegroundColor = Colors.White;
+            }
+            else
+            {
+                titleBar.ButtonForegroundColor = Colors.Black;
+                titleBar.ButtonInactiveForegroundColor = Colors.Gray;
+                titleBar.ButtonHoverBackgroundColor = Color.FromArgb(100, 200, 200, 200);
+                titleBar.ButtonHoverForegroundColor = Colors.Black;
+                titleBar.ButtonPressedBackgroundColor = Color.FromArgb(200, 200, 200, 200);
+                titleBar.ButtonPressedForegroundColor = Colors.Black;
+            }
+        }
+        catch
+        {
+            // Title bar customization not supported on this platform
+        }
 #endif
-	}
+    }
 
-	private void OnColorValuesChanged(UISettings sender, object args)
-	{
-		_windowShellProvider.DispatcherQueue.TryEnqueue(UpdateTitleBarTheming);
-	}
+    private void OnColorValuesChanged(UISettings sender, object args)
+    {
+        _windowShellProvider.DispatcherQueue.TryEnqueue(UpdateTitleBarTheming);
+    }
 
-	public void Dispose()
-	{
-		_uiSettings.ColorValuesChanged -= OnColorValuesChanged;
-	}
+    public void Dispose()
+    {
+        _uiSettings.ColorValuesChanged -= OnColorValuesChanged;
+    }
 }

--- a/src/AppTemplate/ViewModels/MainViewModel.cs
+++ b/src/AppTemplate/ViewModels/MainViewModel.cs
@@ -4,11 +4,11 @@ namespace AppTemplate.ViewModels;
 
 public partial class MainViewModel : ViewModelBase
 {
-	private readonly IStringLocalizer _localizer;
+    private readonly IStringLocalizer _localizer;
 
-	public MainViewModel(IStringLocalizer localizer)
-	{
-		_localizer = localizer;
-		PageTitle = _localizer["ApplicationName"];
-	}
+    public MainViewModel(IStringLocalizer localizer)
+    {
+        _localizer = localizer;
+        PageTitle = _localizer["ApplicationName"];
+    }
 }

--- a/src/AppTemplate/ViewModels/SettingsViewModel.cs
+++ b/src/AppTemplate/ViewModels/SettingsViewModel.cs
@@ -6,71 +6,71 @@ namespace AppTemplate.ViewModels;
 
 public partial class SettingsViewModel : ViewModelBase
 {
-	private readonly IStringLocalizer _localizer;
-	private readonly IAppPreferences _appPreferences;
-	private readonly IThemeManager _themeManager;
-	private bool _isInitializing;
+    private readonly IStringLocalizer _localizer;
+    private readonly IAppPreferences _appPreferences;
+    private readonly IThemeManager _themeManager;
+    private bool _isInitializing;
 
-	public SettingsViewModel(
-		IStringLocalizer localizer,
-		IAppPreferences appPreferences,
-		IThemeManager themeManager)
-	{
-		_localizer = localizer;
-		_appPreferences = appPreferences;
-		_themeManager = themeManager;
-		PageTitle = _localizer["Settings"];
-	}
+    public SettingsViewModel(
+        IStringLocalizer localizer,
+        IAppPreferences appPreferences,
+        IThemeManager themeManager)
+    {
+        _localizer = localizer;
+        _appPreferences = appPreferences;
+        _themeManager = themeManager;
+        PageTitle = _localizer["Settings"];
+    }
 
-	public override void OnNavigatedTo(object? parameter)
-	{
-		base.OnNavigatedTo(parameter);
-		try
-		{
-			_isInitializing = true;
-			Theme = _appPreferences.Theme;
-		}
-		finally
-		{
-			_isInitializing = false;
-		}
-	}
+    public override void OnNavigatedTo(object? parameter)
+    {
+        base.OnNavigatedTo(parameter);
+        try
+        {
+            _isInitializing = true;
+            Theme = _appPreferences.Theme;
+        }
+        finally
+        {
+            _isInitializing = false;
+        }
+    }
 
-	public ElementTheme[] ThemeOptions { get; } = [ElementTheme.Default, ElementTheme.Light, ElementTheme.Dark];
+    public ElementTheme[] ThemeOptions { get; } = [ElementTheme.Default, ElementTheme.Light, ElementTheme.Dark];
 
-	[ObservableProperty]
-	public partial ElementTheme Theme { get; set; }
+    [ObservableProperty]
+    public partial ElementTheme Theme { get; set; }
 
-	partial void OnThemeChanged(ElementTheme value)
-	{
-		if (_isInitializing)
-		{
-			return;
-		}
+    partial void OnThemeChanged(ElementTheme value)
+    {
+        if (_isInitializing)
+        {
+            return;
+        }
 
-		_themeManager.SetTheme(value);
-		_appPreferences.Theme = value;
-	}
+        _themeManager.SetTheme(value);
+        _appPreferences.Theme = value;
+    }
 
-	public string AppVersion
-	{
-		get
-		{
-			var version = Windows.ApplicationModel.Package.Current.Id.Version;
-			return $"{version.Major}.{version.Minor}.{version.Build}";
-		}
-	}
+    public string AppVersion
+    {
+        get
+        {
+            var version = Windows.ApplicationModel.Package.Current.Id.Version;
+            return $"{version.Major}.{version.Minor}.{version.Build}";
+        }
+    }
 
-	public bool IsDebug =>
+    public bool IsDebug =>
 #if DEBUG
-		true;
+        true;
 #else
 		false;
 #endif
 
-	[RelayCommand]
-	private void ClearPreferences()
-	{
-		Windows.Storage.ApplicationData.Current.LocalSettings.Values.Clear();
-	}
+    [RelayCommand]
+    private void ClearPreferences()
+    {
+        Windows.Storage.ApplicationData.Current.LocalSettings.Values.Clear();
+    }
 }

--- a/src/AppTemplate/Views/MainView.xaml.cs
+++ b/src/AppTemplate/Views/MainView.xaml.cs
@@ -8,8 +8,8 @@ public partial class MainViewBase : ViewBase<MainViewModel> { }
 
 public sealed partial class MainView : MainViewBase
 {
-	public MainView()
-	{
-		this.InitializeComponent();
-	}
+    public MainView()
+    {
+        this.InitializeComponent();
+    }
 }

--- a/src/AppTemplate/Views/SettingsView.xaml.cs
+++ b/src/AppTemplate/Views/SettingsView.xaml.cs
@@ -8,8 +8,8 @@ public partial class SettingsViewBase : ViewBase<SettingsViewModel> { }
 
 public sealed partial class SettingsView : SettingsViewBase
 {
-	public SettingsView()
-	{
-		this.InitializeComponent();
-	}
+    public SettingsView()
+    {
+        this.InitializeComponent();
+    }
 }

--- a/src/AppTemplate/Views/ViewBase.cs
+++ b/src/AppTemplate/Views/ViewBase.cs
@@ -5,107 +5,107 @@ using Microsoft.UI.Xaml.Navigation;
 namespace AppTemplate.Views;
 
 public abstract partial class ViewBase<TViewModel> : Page
-	where TViewModel : ViewModelBase
+    where TViewModel : ViewModelBase
 {
-	private object? _pendingParameter;
-	private bool _isNavigationDeferred;
+    private object? _pendingParameter;
+    private bool _isNavigationDeferred;
 
-	protected ViewBase()
-	{
-		Loading += OnPageLoading;
-		Loaded += OnPageLoaded;
-		Unloaded += OnPageUnloaded;
-	}
+    protected ViewBase()
+    {
+        Loading += OnPageLoading;
+        Loaded += OnPageLoaded;
+        Unloaded += OnPageUnloaded;
+    }
 
-	public TViewModel? ViewModel { get; private set; }
+    public TViewModel? ViewModel { get; private set; }
 
-	[MemberNotNull(nameof(ViewModel))]
-	private void EnsureViewModel()
-	{
-		if (ViewModel is not null)
-		{
-			return;
-		}
+    [MemberNotNull(nameof(ViewModel))]
+    private void EnsureViewModel()
+    {
+        if (ViewModel is not null)
+        {
+            return;
+        }
 
-		if (FindWindowShell(Frame.XamlRoot?.Content) is not WindowShell windowShell)
-		{
-			throw new InvalidOperationException("View must be hosted inside a WindowShell.");
-		}
+        if (FindWindowShell(Frame.XamlRoot?.Content) is not WindowShell windowShell)
+        {
+            throw new InvalidOperationException("View must be hosted inside a WindowShell.");
+        }
 
-		ViewModel = windowShell.ServiceProvider.GetRequiredService<TViewModel>();
-		DataContext = ViewModel;
-		ViewModel.ViewCreated();
-	}
+        ViewModel = windowShell.ServiceProvider.GetRequiredService<TViewModel>();
+        DataContext = ViewModel;
+        ViewModel.ViewCreated();
+    }
 
-	private bool TryEnsureViewModel()
-	{
-		if (ViewModel is not null)
-		{
-			return true;
-		}
+    private bool TryEnsureViewModel()
+    {
+        if (ViewModel is not null)
+        {
+            return true;
+        }
 
-		if (FindWindowShell(Frame?.XamlRoot?.Content) is not WindowShell windowShell)
-		{
-			return false;
-		}
+        if (FindWindowShell(Frame?.XamlRoot?.Content) is not WindowShell windowShell)
+        {
+            return false;
+        }
 
-		ViewModel = windowShell.ServiceProvider.GetRequiredService<TViewModel>();
-		DataContext = ViewModel;
-		ViewModel.ViewCreated();
-		return true;
-	}
+        ViewModel = windowShell.ServiceProvider.GetRequiredService<TViewModel>();
+        DataContext = ViewModel;
+        ViewModel.ViewCreated();
+        return true;
+    }
 
-	private static WindowShell? FindWindowShell(UIElement? windowRoot)
-	{
-		if (windowRoot is WindowShell shell)
-		{
-			return shell;
-		}
+    private static WindowShell? FindWindowShell(UIElement? windowRoot)
+    {
+        if (windowRoot is WindowShell shell)
+        {
+            return shell;
+        }
 
-		// Handles Hot Design taking over the root
-		if (windowRoot is ContentControl { Content: WindowShell contentShell })
-		{
-			return contentShell;
-		}
+        // Handles Hot Design taking over the root
+        if (windowRoot is ContentControl { Content: WindowShell contentShell })
+        {
+            return contentShell;
+        }
 
-		return null;
-	}
+        return null;
+    }
 
-	private void OnPageLoading(FrameworkElement sender, object args)
-	{
-		EnsureViewModel();
-		if (_isNavigationDeferred)
-		{
-			ViewModel.OnNavigatedTo(_pendingParameter);
-			_pendingParameter = null;
-			_isNavigationDeferred = false;
-		}
-		ViewModel.ViewLoading();
-	}
+    private void OnPageLoading(FrameworkElement sender, object args)
+    {
+        EnsureViewModel();
+        if (_isNavigationDeferred)
+        {
+            ViewModel.OnNavigatedTo(_pendingParameter);
+            _pendingParameter = null;
+            _isNavigationDeferred = false;
+        }
+        ViewModel.ViewLoading();
+    }
 
-	private void OnPageLoaded(object sender, RoutedEventArgs e) => ViewModel?.ViewLoaded();
+    private void OnPageLoaded(object sender, RoutedEventArgs e) => ViewModel?.ViewLoaded();
 
-	private void OnPageUnloaded(object sender, RoutedEventArgs e) => ViewModel?.ViewUnloaded();
+    private void OnPageUnloaded(object sender, RoutedEventArgs e) => ViewModel?.ViewUnloaded();
 
-	protected override void OnNavigatedTo(NavigationEventArgs e)
-	{
-		base.OnNavigatedTo(e);
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
 
-		if (TryEnsureViewModel())
-		{
-			ViewModel!.OnNavigatedTo(e.Parameter);
-		}
-		else
-		{
-			// XamlRoot not yet available — defer until Loading event
-			_isNavigationDeferred = true;
-			_pendingParameter = e.Parameter;
-		}
-	}
+        if (TryEnsureViewModel())
+        {
+            ViewModel!.OnNavigatedTo(e.Parameter);
+        }
+        else
+        {
+            // XamlRoot not yet available — defer until Loading event
+            _isNavigationDeferred = true;
+            _pendingParameter = e.Parameter;
+        }
+    }
 
-	protected override void OnNavigatedFrom(NavigationEventArgs e)
-	{
-		base.OnNavigatedFrom(e);
-		ViewModel?.OnNavigatedFrom();
-	}
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
+    {
+        base.OnNavigatedFrom(e);
+        ViewModel?.OnNavigatedFrom();
+    }
 }

--- a/src/AppTemplate/WindowShell.xaml.cs
+++ b/src/AppTemplate/WindowShell.xaml.cs
@@ -13,211 +13,211 @@ namespace AppTemplate;
 
 public sealed partial class WindowShell : Page, IWindowShell
 {
-	private readonly IServiceScope _windowScope;
-	private readonly Window _associatedWindow;
-	private bool _isWindowClosed;
-	private ViewModelBase? _currentPageViewModel;
+    private readonly IServiceScope _windowScope;
+    private readonly Window _associatedWindow;
+    private bool _isWindowClosed;
+    private ViewModelBase? _currentPageViewModel;
 
-	public WindowShell(IServiceProvider serviceProvider, Window associatedWindow)
-	{
-		InitializeComponent();
+    public WindowShell(IServiceProvider serviceProvider, Window associatedWindow)
+    {
+        InitializeComponent();
 
-		_windowScope = serviceProvider.CreateScope();
-		var windowShellProvider = (WindowShellProvider)ServiceProvider.GetRequiredService<IWindowShellProvider>();
-		windowShellProvider.SetShell(this, associatedWindow);
+        _windowScope = serviceProvider.CreateScope();
+        var windowShellProvider = (WindowShellProvider)ServiceProvider.GetRequiredService<IWindowShellProvider>();
+        windowShellProvider.SetShell(this, associatedWindow);
 
-		var navigationService = ServiceProvider.GetRequiredService<INavigationService>();
-		navigationService.Initialize();
+        var navigationService = ServiceProvider.GetRequiredService<INavigationService>();
+        navigationService.Initialize();
 
-		// Restore saved theme
-		var settings = ServiceProvider.GetRequiredService<IAppPreferences>();
-		var themeManager = ServiceProvider.GetRequiredService<IThemeManager>();
-		themeManager.SetTheme(settings.Theme);
+        // Restore saved theme
+        var settings = ServiceProvider.GetRequiredService<IAppPreferences>();
+        var themeManager = ServiceProvider.GetRequiredService<IThemeManager>();
+        themeManager.SetTheme(settings.Theme);
 
-		_associatedWindow = associatedWindow;
-		_associatedWindow.Closed += OnWindowClosed;
-		CustomizeWindow();
+        _associatedWindow = associatedWindow;
+        _associatedWindow.Closed += OnWindowClosed;
+        CustomizeWindow();
 
-		ViewModel = ServiceProvider.GetRequiredService<WindowShellViewModel>();
-		ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+        ViewModel = ServiceProvider.GetRequiredService<WindowShellViewModel>();
+        ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
-		InnerFrame.Navigated += InnerFrame_Navigated;
-		Loading += WindowShell_Loading;
+        InnerFrame.Navigated += InnerFrame_Navigated;
+        Loading += WindowShell_Loading;
 
-		UpdateWindowTitle();
-	}
+        UpdateWindowTitle();
+    }
 
-	public IServiceProvider ServiceProvider => _windowScope.ServiceProvider;
+    public IServiceProvider ServiceProvider => _windowScope.ServiceProvider;
 
-	public WindowShellViewModel ViewModel { get; }
+    public WindowShellViewModel ViewModel { get; }
 
-	public Frame RootFrame => InnerFrame;
+    public Frame RootFrame => InnerFrame;
 
-	public bool HasCustomTitleBar { get; private set; }
+    public bool HasCustomTitleBar { get; private set; }
 
-	private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-	{
-		if (e.PropertyName == nameof(WindowShellViewModel.Title))
-		{
-			UpdateWindowTitle();
-		}
-	}
+    private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(WindowShellViewModel.Title))
+        {
+            UpdateWindowTitle();
+        }
+    }
 
-	private void UpdateWindowTitle()
-	{
-		if (ViewModel.Title is not null && !_isWindowClosed)
-		{
-			_associatedWindow.Title = ViewModel.Title;
-		}
-	}
+    private void UpdateWindowTitle()
+    {
+        if (ViewModel.Title is not null && !_isWindowClosed)
+        {
+            _associatedWindow.Title = ViewModel.Title;
+        }
+    }
 
-	private void InnerFrame_Navigated(object sender, Microsoft.UI.Xaml.Navigation.NavigationEventArgs e)
-	{
-		// Unsubscribe from previous page's ViewModel
-		if (_currentPageViewModel is not null)
-		{
-			_currentPageViewModel.PropertyChanged -= PageViewModel_PropertyChanged;
-			_currentPageViewModel = null;
-		}
+    private void InnerFrame_Navigated(object sender, Microsoft.UI.Xaml.Navigation.NavigationEventArgs e)
+    {
+        // Unsubscribe from previous page's ViewModel
+        if (_currentPageViewModel is not null)
+        {
+            _currentPageViewModel.PropertyChanged -= PageViewModel_PropertyChanged;
+            _currentPageViewModel = null;
+        }
 
-		// Subscribe to new page's ViewModel for title updates
-		if (e.Content is FrameworkElement { DataContext: ViewModelBase pageViewModel })
-		{
-			_currentPageViewModel = pageViewModel;
-			_currentPageViewModel.PropertyChanged += PageViewModel_PropertyChanged;
-			UpdatePageTitle();
-		}
-		else
-		{
-			ViewModel.Title = ServiceProvider.GetRequiredService<IStringLocalizer>()["ApplicationName"];
-		}
+        // Subscribe to new page's ViewModel for title updates
+        if (e.Content is FrameworkElement { DataContext: ViewModelBase pageViewModel })
+        {
+            _currentPageViewModel = pageViewModel;
+            _currentPageViewModel.PropertyChanged += PageViewModel_PropertyChanged;
+            UpdatePageTitle();
+        }
+        else
+        {
+            ViewModel.Title = ServiceProvider.GetRequiredService<IStringLocalizer>()["ApplicationName"];
+        }
 
-		ViewModel.NotifyCanGoBackChanged();
-		UpdateNavigationViewSelection();
-	}
+        ViewModel.NotifyCanGoBackChanged();
+        UpdateNavigationViewSelection();
+    }
 
-	private void PageViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-	{
-		if (e.PropertyName == nameof(ViewModelBase.PageTitle))
-		{
-			UpdatePageTitle();
-		}
-	}
+    private void PageViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ViewModelBase.PageTitle))
+        {
+            UpdatePageTitle();
+        }
+    }
 
-	private void UpdatePageTitle()
-	{
-		if (_currentPageViewModel is not null)
-		{
-			ViewModel.Title = _currentPageViewModel.PageTitle
-				?? ServiceProvider.GetRequiredService<IStringLocalizer>()["ApplicationName"];
-		}
-	}
+    private void UpdatePageTitle()
+    {
+        if (_currentPageViewModel is not null)
+        {
+            ViewModel.Title = _currentPageViewModel.PageTitle
+                ?? ServiceProvider.GetRequiredService<IStringLocalizer>()["ApplicationName"];
+        }
+    }
 
-	private void OnWindowClosed(object sender, WindowEventArgs args)
-	{
-		_isWindowClosed = true;
-		_associatedWindow.Closed -= OnWindowClosed;
-		InnerFrame.Navigated -= InnerFrame_Navigated;
-		ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
-		if (_currentPageViewModel is not null)
-		{
-			_currentPageViewModel.PropertyChanged -= PageViewModel_PropertyChanged;
-			_currentPageViewModel = null;
-		}
-	}
+    private void OnWindowClosed(object sender, WindowEventArgs args)
+    {
+        _isWindowClosed = true;
+        _associatedWindow.Closed -= OnWindowClosed;
+        InnerFrame.Navigated -= InnerFrame_Navigated;
+        ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
+        if (_currentPageViewModel is not null)
+        {
+            _currentPageViewModel.PropertyChanged -= PageViewModel_PropertyChanged;
+            _currentPageViewModel = null;
+        }
+    }
 
-	private void WindowShell_Loading(FrameworkElement sender, object args)
-	{
-		var windowShellProvider = (WindowShellProvider)ServiceProvider.GetRequiredService<IWindowShellProvider>();
-		windowShellProvider.SetXamlRoot(XamlRoot ?? throw new InvalidOperationException("XamlRoot must be set."));
-	}
+    private void WindowShell_Loading(FrameworkElement sender, object args)
+    {
+        var windowShellProvider = (WindowShellProvider)ServiceProvider.GetRequiredService<IWindowShellProvider>();
+        windowShellProvider.SetXamlRoot(XamlRoot ?? throw new InvalidOperationException("XamlRoot must be set."));
+    }
 
-	public void SetTitleBar(UIElement? titleBar)
-	{
-		if (!_isWindowClosed)
-		{
-			_associatedWindow.SetTitleBar(titleBar ?? TitleBarGrid);
-		}
-	}
+    public void SetTitleBar(UIElement? titleBar)
+    {
+        if (!_isWindowClosed)
+        {
+            _associatedWindow.SetTitleBar(titleBar ?? TitleBarGrid);
+        }
+    }
 
-	private void CustomizeWindow()
-	{
+    private void CustomizeWindow()
+    {
 #if !HAS_UNO
-		if (AppWindowTitleBar.IsCustomizationSupported())
-		{
-			_associatedWindow.ExtendsContentIntoTitleBar = true;
-			_associatedWindow.AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
-			_associatedWindow.SetTitleBar(TitleBarGrid);
-			HasCustomTitleBar = true;
-		}
+        if (AppWindowTitleBar.IsCustomizationSupported())
+        {
+            _associatedWindow.ExtendsContentIntoTitleBar = true;
+            _associatedWindow.AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
+            _associatedWindow.SetTitleBar(TitleBarGrid);
+            HasCustomTitleBar = true;
+        }
 #endif
 
-		if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Window", "SystemBackdrop"))
-		{
-			_associatedWindow.SystemBackdrop = new MicaBackdrop();
-			Background = null;
-		}
-	}
+        if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Window", "SystemBackdrop"))
+        {
+            _associatedWindow.SystemBackdrop = new MicaBackdrop();
+            Background = null;
+        }
+    }
 
-	#region Navigation
+    #region Navigation
 
-	private void NavView_Loaded(object sender, RoutedEventArgs e)
-		=> NavigateToSection(NavigationSection.Main);
+    private void NavView_Loaded(object sender, RoutedEventArgs e)
+        => NavigateToSection(NavigationSection.Main);
 
-	private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
-	{
-		if (args.SelectedItemContainer is not NavigationViewItem item)
-		{
-			return;
-		}
+    private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
+    {
+        if (args.SelectedItemContainer is not NavigationViewItem item)
+        {
+            return;
+        }
 
-		var tag = item.Tag?.ToString();
-		if (tag is null && item == (NavigationViewItem)sender.SettingsItem)
-		{
-			tag = NavigationSection.Settings.ToString();
-		}
+        var tag = item.Tag?.ToString();
+        if (tag is null && item == (NavigationViewItem)sender.SettingsItem)
+        {
+            tag = NavigationSection.Settings.ToString();
+        }
 
-		if (Enum.TryParse<NavigationSection>(tag, out var section))
-		{
-			NavigateToSection(section);
-		}
-	}
+        if (Enum.TryParse<NavigationSection>(tag, out var section))
+        {
+            NavigateToSection(section);
+        }
+    }
 
-	private void NavigateToSection(NavigationSection section)
-	{
-		var nav = ServiceProvider.GetRequiredService<INavigationService>();
-		switch (section)
-		{
-			case NavigationSection.Main:
-				nav.Navigate<MainViewModel>();
-				break;
-			case NavigationSection.Settings:
-				nav.Navigate<SettingsViewModel>();
-				break;
-			default:
-				throw new NotSupportedException($"Navigation section not supported: {section}");
-		}
-	}
+    private void NavigateToSection(NavigationSection section)
+    {
+        var nav = ServiceProvider.GetRequiredService<INavigationService>();
+        switch (section)
+        {
+            case NavigationSection.Main:
+                nav.Navigate<MainViewModel>();
+                break;
+            case NavigationSection.Settings:
+                nav.Navigate<SettingsViewModel>();
+                break;
+            default:
+                throw new NotSupportedException($"Navigation section not supported: {section}");
+        }
+    }
 
-	private void NavView_BackRequested(NavigationView sender, NavigationViewBackRequestedEventArgs args)
-	{
-		var nav = ServiceProvider.GetRequiredService<INavigationService>();
-		if (nav.GoBack())
-		{
-			UpdateNavigationViewSelection();
-		}
-	}
+    private void NavView_BackRequested(NavigationView sender, NavigationViewBackRequestedEventArgs args)
+    {
+        var nav = ServiceProvider.GetRequiredService<INavigationService>();
+        if (nav.GoBack())
+        {
+            UpdateNavigationViewSelection();
+        }
+    }
 
-	private void UpdateNavigationViewSelection()
-	{
-		var section = ServiceProvider.GetRequiredService<INavigationService>().CurrentSection;
-		NavView.SelectedItem = section switch
-		{
-			NavigationSection.Main => MainNavItem,
-			NavigationSection.Settings => NavView.SettingsItem,
-			_ => NavView.SelectedItem,
-		};
-	}
+    private void UpdateNavigationViewSelection()
+    {
+        var section = ServiceProvider.GetRequiredService<INavigationService>().CurrentSection;
+        NavView.SelectedItem = section switch
+        {
+            NavigationSection.Main => MainNavItem,
+            NavigationSection.Settings => NavView.SettingsItem,
+            _ => NavView.SelectedItem,
+        };
+    }
 
-	#endregion
+    #endregion
 }

--- a/tests/AppTemplate.Core.Tests/MSTestSettings.cs
+++ b/tests/AppTemplate.Core.Tests/MSTestSettings.cs
@@ -1,1 +1,1 @@
-﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]
+[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]


### PR DESCRIPTION
@
## What

Runs `dotnet format whitespace` across the whole solution so all C# files match the existing `.editorconfig` (`indent_style = space`).

## Why

Every C# file in the repo used **tabs**, but `.editorconfig` specifies **spaces**. As a result, any `dotnet format` run (which contributors and agents do before committing) reformatted every touched file tabs→spaces, producing large unrelated whitespace diffs in otherwise-small feature PRs.

After this change `dotnet format` / `dotnet format whitespace` is **idempotent** (`--verify-no-changes` passes), so feature PRs stay focused on their actual changes.

## Scope

- 50 `.cs` files, whitespace-only (verified: `git diff -w` shows no code changes).
- Strips a stray UTF-8 BOM from `MSTestSettings.cs` per the editorconfig `charset = utf-8` rule.
- No XAML changes (XAML formatting is handled separately via XAML Styler, see #37/#41).
- No behavioral changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@