### PR TITLE
feat: add IsWorking observable to ViewModelBase (#15)

### DIFF
--- a/src/AppTemplate.Core/ViewModels/ViewModelBase.cs
+++ b/src/AppTemplate.Core/ViewModels/ViewModelBase.cs
@@ -2,8 +2,23 @@ namespace AppTemplate.Core.ViewModels;
 
 public abstract partial class ViewModelBase : ObservableObject
 {
+    /// <summary>
+    /// Gets or sets a value indicating whether the view model is performing its
+    /// initial data load. This represents the busy state triggered when the view is
+    /// entered/navigated to (for example, fetching the data needed to render the page).
+    /// Use this to drive a full-page loading indicator while the view is being populated.
+    /// </summary>
     [ObservableProperty]
     public partial bool IsLoading { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the view model is busy running a
+    /// user-initiated action or command on an already-loaded view (for example,
+    /// saving changes or submitting a form). Use this to drive an inline busy
+    /// indicator and to disable command-bound controls while the action runs.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsWorking { get; set; }
 
     [ObservableProperty]
     public partial string? PageTitle { get; set; }

--- a/src/AppTemplate/Views/MainView.xaml
+++ b/src/AppTemplate/Views/MainView.xaml
@@ -6,6 +6,7 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid Padding="24">
+        <!-- Content -->
         <StackPanel
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
@@ -20,6 +21,27 @@
                 HorizontalAlignment="Center"
                 Style="{ThemeResource TitleLargeTextBlockStyle}"
                 Text="Hello Uno Platform!" />
+
+            <!--
+                Busy state example: IsWorking is set while a user-initiated command
+                runs on an already-loaded view. Drive an inline busy indicator from it
+                and disable the triggering control until the action completes.
+            -->
+            <ProgressRing
+                HorizontalAlignment="Center"
+                IsActive="{Binding IsWorking, Mode=OneWay}" />
         </StackPanel>
+
+        <!--
+            Initial-load example: IsLoading is set while the view fetches the data it
+            needs when it is entered/navigated to. Show a full-page loading indicator
+            until the data is ready.
+        -->
+        <ProgressRing
+            Width="48"
+            Height="48"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            IsActive="{Binding IsLoading, Mode=OneWay}" />
     </Grid>
 </local:MainViewBase>

--- a/src/AppTemplate/Views/MainView.xaml
+++ b/src/AppTemplate/Views/MainView.xaml
@@ -29,7 +29,7 @@
             -->
             <ProgressRing
                 HorizontalAlignment="Center"
-                IsActive="{Binding IsWorking, Mode=OneWay}" />
+                IsActive="{x:Bind ViewModel.IsWorking, Mode=OneWay}" />
         </StackPanel>
 
         <!--
@@ -42,6 +42,6 @@
             Height="48"
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
-            IsActive="{Binding IsLoading, Mode=OneWay}" />
+            IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
     </Grid>
 </local:MainViewBase>


### PR DESCRIPTION
## Summary

Reconciles the busy-state properties on `ViewModelBase` per issue #15. Adds an `IsWorking` observable property alongside the existing `IsLoading`, with XML-doc comments that establish clear, distinct semantics. **Both properties are kept.**

| Property | Meaning |
| --- | --- |
| `IsLoading` | Initial data load triggered when the view is entered/navigated to (e.g. fetching the data needed to render the page). Drives a full-page loading indicator. |
| `IsWorking` | Busy state for a user-initiated action/command running on an already-loaded view (e.g. saving changes, submitting a form). Drives an inline busy indicator and disables the triggering control. |

## Changes

- `src/AppTemplate.Core/ViewModels/ViewModelBase.cs` — added `[ObservableProperty] public partial bool IsWorking { get; set; }` (matching the existing partial-property `[ObservableProperty]` style) with XML-doc comments distinguishing it from `IsLoading`.
- `src/AppTemplate/Views/MainView.xaml` — added representative, commented data-binding examples (a `ProgressRing` bound to each property) demonstrating the two states.

## Build status

- `dotnet format whitespace src/AppTemplate.Core/AppTemplate.Core.csproj` — clean, no unrelated whitespace changes.
- `dotnet build src/AppTemplate.Core/AppTemplate.Core.csproj -f net10.0` — **Build succeeded, 0 errors** (one pre-existing, unrelated NU1507 package-source-mapping warning).

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)