### PR TITLE
feat: add IViewBase interface alongside ViewBase (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-# template
+# App Template
 
 ## Views
 
 ### `IViewBase`
 
-`ViewBase<TViewModel>` is the generic base class for views (pages). It resolves the view
-model from the hosting `WindowShell` service provider and forwards lifecycle events to it.
+`ViewBase<TViewModel>` is the base class for views (pages). It resolves the view model from the
+hosting `WindowShell` service provider and forwards lifecycle events to it.
 
-`IViewBase` is a non-generic interface that exposes the type-erased surface of
-`ViewBase<TViewModel>` — currently the resolved view model as `object?`:
+`IViewBase` is a non-generic interface that exposes the resolved view model as `object?`:
 
 ```csharp
 public interface IViewBase
@@ -17,12 +16,12 @@ public interface IViewBase
 }
 ```
 
-Every `ViewBase<TViewModel>` implements `IViewBase`, so you can reference a view through the
-interface without taking a dependency on the concrete generic type.
+Every `ViewBase<TViewModel>` implements `IViewBase`, so a view can be referenced through the
+interface without depending on its concrete view model type.
 
 Use it when:
 
-- A `DataTemplate` (or other shared/loosely-typed code) needs to call into a view without
-  knowing — or depending on — the specific view model generic argument.
+- A `DataTemplate` (or other loosely-typed code) needs to reach a view's view model without
+  knowing its generic argument.
 - A test needs to inspect a view's resolved view model without knowing its concrete type at
   compile time.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # template
+
+## Views
+
+### `IViewBase`
+
+`ViewBase<TViewModel>` is the generic base class for views (pages). It resolves the view
+model from the hosting `WindowShell` service provider and forwards lifecycle events to it.
+
+`IViewBase` is a non-generic interface that exposes the type-erased surface of
+`ViewBase<TViewModel>` — currently the resolved view model as `object?`:
+
+```csharp
+public interface IViewBase
+{
+    object? ViewModel { get; }
+}
+```
+
+Every `ViewBase<TViewModel>` implements `IViewBase`, so you can reference a view through the
+interface without taking a dependency on the concrete generic type.
+
+Use it when:
+
+- A `DataTemplate` (or other shared/loosely-typed code) needs to call into a view without
+  knowing — or depending on — the specific view model generic argument.
+- A test needs to inspect a view's resolved view model without knowing its concrete type at
+  compile time.

--- a/src/AppTemplate/Views/IViewBase.cs
+++ b/src/AppTemplate/Views/IViewBase.cs
@@ -1,0 +1,18 @@
+namespace AppTemplate.Views;
+
+/// <summary>
+/// Non-generic, type-erased surface of <see cref="ViewBase{TViewModel}"/>.
+/// </summary>
+/// <remarks>
+/// Useful when a consumer (for example a <c>DataTemplate</c>) needs to reference a view without
+/// taking a dependency on the concrete <see cref="ViewBase{TViewModel}"/> generic type, or when a
+/// view needs to be referenced from a test without knowing its view model type at compile time.
+/// </remarks>
+public interface IViewBase
+{
+    /// <summary>
+    /// Gets the view model associated with the view, or <see langword="null"/> if it has not been
+    /// resolved yet.
+    /// </summary>
+    object? ViewModel { get; }
+}

--- a/src/AppTemplate/Views/ViewBase.cs
+++ b/src/AppTemplate/Views/ViewBase.cs
@@ -4,7 +4,7 @@ using Microsoft.UI.Xaml.Navigation;
 
 namespace AppTemplate.Views;
 
-public abstract partial class ViewBase<TViewModel> : Page
+public abstract partial class ViewBase<TViewModel> : Page, IViewBase
     where TViewModel : ViewModelBase
 {
     private object? _pendingParameter;
@@ -18,6 +18,8 @@ public abstract partial class ViewBase<TViewModel> : Page
     }
 
     public TViewModel? ViewModel { get; private set; }
+
+    object? IViewBase.ViewModel => ViewModel;
 
     [MemberNotNull(nameof(ViewModel))]
     private void EnsureViewModel()


### PR DESCRIPTION
## Summary

Adds a non-generic `IViewBase` interface alongside the existing generic `ViewBase<TViewModel>` concrete base class.

- Adds `src/AppTemplate/Views/IViewBase.cs` — a non-generic interface exposing the type-erased surface of `ViewBase<TViewModel>`: the resolved view model as `object? ViewModel { get; }`.
- `ViewBase<TViewModel>` now implements `IViewBase` via an explicit interface implementation (`object? IViewBase.ViewModel => ViewModel;`) that delegates to the strongly-typed `ViewModel` property, leaving the existing public API unchanged.
- Documents the use case in the root `README.md`.

## Use case

This lets `DataTemplate`s (and other loosely-typed/shared code) call into a view without taking a dependency on the concrete `ViewBase<TViewModel>` generic type, and lets tests inspect a view's resolved view model without knowing its concrete type at compile time.

## Build status

`dotnet build src/AppTemplate/AppTemplate.csproj -f net10.0-desktop` — **Build succeeded**, 0 errors. (Only pre-existing, unrelated warnings: NU1507 package-source mapping and a Uno0001 not-implemented warning in `NavigationService`.)

`dotnet format whitespace` was run before committing.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)