### PR TITLE
feat: add IFrameProvider/FrameProvider navigation abstraction (#24)

### DIFF
--- a/src/AppTemplate/App.xaml.cs
+++ b/src/AppTemplate/App.xaml.cs
@@ -94,6 +94,7 @@ public partial class App : Application, IApplication
         services.AddScoped<WindowShellProvider>();
         services.AddScoped<IWindowShellProvider>(sp => sp.GetRequiredService<WindowShellProvider>());
         services.AddScoped<IXamlRootProvider>(sp => sp.GetRequiredService<WindowShellProvider>());
+        services.AddScoped<IFrameProvider, FrameProvider>();
         services.AddScoped<IDialogCoordinator, DialogCoordinator>();
         services.AddScoped<IDialogService, DialogService>();
         services.AddScoped<IConfirmationDialogService, ConfirmationDialogService>();
@@ -101,7 +102,7 @@ public partial class App : Application, IApplication
         services.AddScoped<IShareService, ShareService>();
         services.AddScoped<INavigationService>(sp =>
         {
-            var service = new NavigationService(sp.GetRequiredService<IWindowShellProvider>());
+            var service = new NavigationService(sp.GetRequiredService<IFrameProvider>());
             service.RegisterView(typeof(Views.MainView), typeof(MainViewModel));
             service.RegisterView(typeof(Views.SettingsView), typeof(SettingsViewModel));
             return service;

--- a/src/AppTemplate/Services/Navigation/FrameProvider.cs
+++ b/src/AppTemplate/Services/Navigation/FrameProvider.cs
@@ -1,0 +1,13 @@
+namespace AppTemplate.Services.Navigation;
+
+internal sealed class FrameProvider : IFrameProvider
+{
+    private readonly IWindowShellProvider _shellProvider;
+
+    public FrameProvider(IWindowShellProvider shellProvider)
+    {
+        _shellProvider = shellProvider;
+    }
+
+    public Frame Frame => _shellProvider.RootFrame;
+}

--- a/src/AppTemplate/Services/Navigation/IFrameProvider.cs
+++ b/src/AppTemplate/Services/Navigation/IFrameProvider.cs
@@ -1,0 +1,6 @@
+namespace AppTemplate.Services.Navigation;
+
+public interface IFrameProvider
+{
+    Frame Frame { get; }
+}

--- a/src/AppTemplate/Services/Navigation/NavigationService.cs
+++ b/src/AppTemplate/Services/Navigation/NavigationService.cs
@@ -11,17 +11,17 @@ namespace AppTemplate.Services.Navigation;
 
 public sealed class NavigationService : INavigationService
 {
-    private readonly IWindowShellProvider _shellProvider;
+    private readonly IFrameProvider _frameProvider;
     private readonly Dictionary<Type, Type> _viewModelToViewMap = new();
     private bool _initialized;
     private bool _backRequestedSubscribed;
 
-    public NavigationService(IWindowShellProvider shellProvider)
+    public NavigationService(IFrameProvider frameProvider)
     {
-        _shellProvider = shellProvider;
+        _frameProvider = frameProvider;
     }
 
-    private Frame Frame => _shellProvider.RootFrame;
+    private Frame Frame => _frameProvider.Frame;
 
     public bool CanGoBack => _initialized && Frame.CanGoBack;
 


### PR DESCRIPTION
## Summary

Decouples navigation `Frame` access from `WindowShell` by introducing an `IFrameProvider` abstraction with a UI-side `FrameProvider` implementation, as requested in #24. This makes the navigation `Frame` a first-class, independently testable dependency and lets non-`WindowShell` hosts plug in their own frame.

Closes #24

## Changes

- **Add `Services/Navigation/IFrameProvider.cs`** — interface exposing a `Frame`-typed `Frame` property.
- **Add `Services/Navigation/FrameProvider.cs`** — `internal sealed` UI-side implementation that obtains the frame from the existing `IWindowShellProvider.RootFrame`, preserving current behavior.
- **Refactor `NavigationService`** — constructor now takes `IFrameProvider` instead of `IWindowShellProvider`; the private `Frame` property delegates to `IFrameProvider.Frame`. All navigation logic is unchanged.
- **DI registration in `App.xaml.cs`** — registers `IFrameProvider` -> `FrameProvider` as **scoped** (mirroring the other per-window navigation services) and updates the `NavigationService` factory to resolve `IFrameProvider`.

This is a behavior-preserving refactor; navigation behavior is identical.

## Build & test status

- `dotnet build src/AppTemplate/AppTemplate.csproj -f net10.0-desktop` — **succeeded, 0 errors** (only pre-existing NU1507 package-source and Uno0001 `SlideNavigationTransitionInfo.Effect` warnings, unrelated to this change).
- `dotnet test tests/AppTemplate.Core.Tests/AppTemplate.Core.Tests.csproj` — test project builds and runs; it currently contains **no test cases** (scaffold only), so the run reports "zero tests ran" (MTP exit code 8). This is the pre-existing baseline, not a regression — the Core test project does not reference the UI head project that this change touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)