### PR TITLE
feat: add code-behind scaffold for Resources/DataTemplates.xaml (#18)

### DIFF
--- a/src/AppTemplate/App.xaml
+++ b/src/AppTemplate/App.xaml
@@ -1,7 +1,8 @@
 ﻿<Application
     x:Class="AppTemplate.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:resources="using:AppTemplate.Resources">
 
     <Application.Resources>
         <ResourceDictionary>
@@ -11,6 +12,7 @@
                 <ResourceDictionary Source="/Resources/Colors.xaml" />
                 <ResourceDictionary Source="/Resources/Converters.xaml" />
                 <ResourceDictionary Source="/Resources/Styles.xaml" />
+                <resources:DataTemplates />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/src/AppTemplate/Models/NavigationMenuItem.cs
+++ b/src/AppTemplate/Models/NavigationMenuItem.cs
@@ -1,7 +1,6 @@
 namespace AppTemplate.Models;
 
 /// <summary>
-/// Represents a single navigation menu entry rendered using the
-/// <c>NavigationMenuItemTemplate</c> defined in <c>Resources/DataTemplates.xaml</c>.
+/// Represents a single navigation menu entry with an icon glyph and a display label.
 /// </summary>
 public sealed record NavigationMenuItem(string Glyph, string Label);

--- a/src/AppTemplate/Models/NavigationMenuItem.cs
+++ b/src/AppTemplate/Models/NavigationMenuItem.cs
@@ -1,0 +1,7 @@
+namespace AppTemplate.Models;
+
+/// <summary>
+/// Represents a single navigation menu entry rendered using the
+/// <c>NavigationMenuItemTemplate</c> defined in <c>Resources/DataTemplates.xaml</c>.
+/// </summary>
+public sealed record NavigationMenuItem(string Glyph, string Label);

--- a/src/AppTemplate/Models/NavigationMenuItem.cs
+++ b/src/AppTemplate/Models/NavigationMenuItem.cs
@@ -1,6 +1,0 @@
-namespace AppTemplate.Models;
-
-/// <summary>
-/// Represents a single navigation menu entry with an icon glyph and a display label.
-/// </summary>
-public sealed record NavigationMenuItem(string Glyph, string Label);

--- a/src/AppTemplate/Resources/DataTemplates.xaml
+++ b/src/AppTemplate/Resources/DataTemplates.xaml
@@ -1,1 +1,18 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />
+<ResourceDictionary
+    x:Class="AppTemplate.Resources.DataTemplates"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:models="using:AppTemplate.Models">
+
+    <!--  Navigation menu item: glyph + label, shared across views  -->
+    <DataTemplate x:Key="NavigationMenuItemTemplate" x:DataType="models:NavigationMenuItem">
+        <StackPanel Orientation="Horizontal" Spacing="12">
+            <FontIcon
+                VerticalAlignment="Center"
+                FontSize="16"
+                Glyph="{x:Bind Glyph}" />
+            <TextBlock VerticalAlignment="Center" Text="{x:Bind Label}" />
+        </StackPanel>
+    </DataTemplate>
+
+</ResourceDictionary>

--- a/src/AppTemplate/Resources/DataTemplates.xaml
+++ b/src/AppTemplate/Resources/DataTemplates.xaml
@@ -1,18 +1,6 @@
 <ResourceDictionary
     x:Class="AppTemplate.Resources.DataTemplates"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:models="using:AppTemplate.Models">
-
-    <!--  Navigation menu item: glyph + label, shared across views  -->
-    <DataTemplate x:Key="NavigationMenuItemTemplate" x:DataType="models:NavigationMenuItem">
-        <StackPanel Orientation="Horizontal" Spacing="12">
-            <FontIcon
-                VerticalAlignment="Center"
-                FontSize="16"
-                Glyph="{x:Bind Glyph}" />
-            <TextBlock VerticalAlignment="Center" Text="{x:Bind Label}" />
-        </StackPanel>
-    </DataTemplate>
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
 </ResourceDictionary>

--- a/src/AppTemplate/Resources/DataTemplates.xaml.cs
+++ b/src/AppTemplate/Resources/DataTemplates.xaml.cs
@@ -1,13 +1,9 @@
 namespace AppTemplate.Resources;
 
 /// <summary>
-/// Centralizes app-wide <see cref="Microsoft.UI.Xaml.DataTemplate" /> definitions so individual
-/// views don't have to redeclare them. Merged into <c>App.xaml</c>'s <c>MergedDictionaries</c>.
+/// Holds app-wide <see cref="DataTemplate" /> definitions shared across views.
 /// </summary>
 public sealed partial class DataTemplates : ResourceDictionary
 {
-    public DataTemplates()
-    {
-        InitializeComponent();
-    }
+    public DataTemplates() => InitializeComponent();
 }

--- a/src/AppTemplate/Resources/DataTemplates.xaml.cs
+++ b/src/AppTemplate/Resources/DataTemplates.xaml.cs
@@ -1,0 +1,13 @@
+namespace AppTemplate.Resources;
+
+/// <summary>
+/// Centralizes app-wide <see cref="Microsoft.UI.Xaml.DataTemplate" /> definitions so individual
+/// views don't have to redeclare them. Merged into <c>App.xaml</c>'s <c>MergedDictionaries</c>.
+/// </summary>
+public sealed partial class DataTemplates : ResourceDictionary
+{
+    public DataTemplates()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary

Converts the previously-empty `Resources/DataTemplates.xaml` into a partial-class `ResourceDictionary` scaffold so app-wide `DataTemplate`s can be added in one place when needed.

## Changes

- **`Resources/DataTemplates.xaml`** — set `x:Class="AppTemplate.Resources.DataTemplates"` on the root `ResourceDictionary` and kept the dictionary intentionally empty as a starter scaffold.
- **`Resources/DataTemplates.xaml.cs`** — new partial-class code-behind calling `InitializeComponent()` in its constructor, mirroring the existing XAML code-behind pattern in the project. The `<Page Update>` / `MSBuild:Compile` generator entry for this file already existed in the csproj.
- **`App.xaml`** — added `xmlns:resources="using:AppTemplate.Resources"` and merged `<resources:DataTemplates />` into `Application.Resources` `MergedDictionaries`.
- **Removed** **`Models/NavigationMenuItem.cs`** — deleted the temporary sample model used only for the removed example template.

## Build status

`dotnet build src/AppTemplate/AppTemplate.csproj -p:TargetFrameworks=net10.0-desktop -p:TargetFramework=net10.0-desktop` — **Build succeeded, 0 errors**. The remaining Uno0001 warning in `NavigationService.cs` is pre-existing and unrelated.

`dotnet format whitespace` was run before staging; the final diff contains only the intended files.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>