### PR TITLE
feat: enable dotnet run for the WinAppSDK head (#38)

### DIFF
--- a/src/AppTemplate/AppTemplate.csproj
+++ b/src/AppTemplate/AppTemplate.csproj
@@ -59,10 +59,9 @@
     <!--
         Enables `dotnet run` for the packaged WinAppSDK (Windows) head.
         The Microsoft.Windows.SDK.BuildTools.WinApp targets hook into `dotnet run`,
-        build a loose-layout package, register it with Windows, and launch it
-        (matching the experience of the `dotnet new winui` templates).
-        See: https://devblogs.microsoft.com/ifdef-windows/introducing-dotnet-new-templates-for-winui/
+        build a loose-layout package, register it with Windows, and launch it.
         Referenced only for the Windows target; PrivateAssets="all" keeps it from flowing transitively.
+        See src/AppTemplate/Platforms/Windows/README.md for details and optional MSBuild properties.
     -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
         <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" PrivateAssets="all" />

--- a/src/AppTemplate/AppTemplate.csproj
+++ b/src/AppTemplate/AppTemplate.csproj
@@ -56,6 +56,18 @@
         <ProjectReference Include="..\AppTemplate.Core\AppTemplate.Core.csproj" />
     </ItemGroup>
 
+    <!--
+        Enables `dotnet run` for the packaged WinAppSDK (Windows) head.
+        The Microsoft.Windows.SDK.BuildTools.WinApp targets hook into `dotnet run`,
+        build a loose-layout package, register it with Windows, and launch it
+        (matching the experience of the `dotnet new winui` templates).
+        See: https://devblogs.microsoft.com/ifdef-windows/introducing-dotnet-new-templates-for-winui/
+        Referenced only for the Windows target; PrivateAssets="all" keeps it from flowing transitively.
+    -->
+    <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
+        <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" PrivateAssets="all" />
+    </ItemGroup>
+
     <ItemGroup>
       <Page Update="Resources\DataTemplates.xaml">
         <Generator>MSBuild:Compile</Generator>

--- a/src/AppTemplate/AppTemplate.csproj
+++ b/src/AppTemplate/AppTemplate.csproj
@@ -56,13 +56,6 @@
         <ProjectReference Include="..\AppTemplate.Core\AppTemplate.Core.csproj" />
     </ItemGroup>
 
-    <!--
-        Enables `dotnet run` for the packaged WinAppSDK (Windows) head.
-        The Microsoft.Windows.SDK.BuildTools.WinApp targets hook into `dotnet run`,
-        build a loose-layout package, register it with Windows, and launch it.
-        Referenced only for the Windows target; PrivateAssets="all" keeps it from flowing transitively.
-        See src/AppTemplate/Platforms/Windows/README.md for details and optional MSBuild properties.
-    -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
         <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" PrivateAssets="all" />
     </ItemGroup>

--- a/src/AppTemplate/Platforms/Windows/README.md
+++ b/src/AppTemplate/Platforms/Windows/README.md
@@ -1,0 +1,73 @@
+# Windows (WinAppSDK) head
+
+On the `net10.0-windows10.0.26100` target framework the app is compiled as a plain
+WinUI / Windows App SDK application using Microsoft's own tooling (Uno Platform is not
+involved at runtime on this head). See
+[How Uno Platform Works](https://platform.uno/docs/articles/how-uno-works.html#windows-using-winappsdk).
+
+## Running from the command line
+
+### Packaged (`dotnet run`)
+
+`dotnet run` support for the packaged WinAppSDK head is provided by the
+[`Microsoft.Windows.SDK.BuildTools.WinApp`](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools.WinApp)
+package (referenced for the Windows target in `AppTemplate.csproj`). Its MSBuild targets
+hook into the standard `dotnet run` pipeline: they build the project, create a
+loose-layout package, register it with Windows (like a real MSIX install) and launch it.
+This mirrors what the new `dotnet new winui` templates support — see
+[Introducing dotnet new templates for WinUI](https://devblogs.microsoft.com/ifdef-windows/introducing-dotnet-new-templates-for-winui/).
+
+```powershell
+# From the src/AppTemplate folder
+dotnet run -f net10.0-windows10.0.26100
+```
+
+The project defaults to a packaged build (`WindowsPackageType=MSIX`), so no extra flags
+are required. Requirements: Windows 10 or later and Developer Mode enabled (or an elevated
+terminal) so the loose-layout package identity can be registered.
+
+Optional MSBuild properties exposed by the package (set on the command line with
+`-p:Name=Value` or in the `.csproj`):
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `EnableWinAppRunSupport` | `true` | Enable/disable the `dotnet run` integration. |
+| `WinAppLaunchArgs` | (empty) | Arguments passed to the app on launch. |
+| `WinAppRunUseExecutionAlias` | `false` | Launch via execution alias instead of AUMID activation (keeps console I/O in the current terminal). |
+| `WinAppRunNoLaunch` | `false` | Register identity without launching (attach your own debugger afterwards). |
+| `WinAppRunDebugOutput` | `false` | Capture `OutputDebugString` and first-chance exceptions. |
+
+### Unpackaged (`dotnet run`)
+
+To run unpackaged, override `WindowsPackageType` so no MSIX identity is created:
+
+```powershell
+# From the src/AppTemplate folder
+dotnet run -f net10.0-windows10.0.26100 -p:WindowsPackageType=None
+```
+
+The matching launch profile is **App Template (WinAppSDK Unpackaged)** in
+`Properties/launchSettings.json` (`commandName: Project`).
+
+### Desktop (Skia) head — for comparison
+
+The cross-platform Skia desktop head runs on Windows (and Linux/macOS) and does not use
+Windows App SDK:
+
+```powershell
+# From the src/AppTemplate folder
+dotnet run -f net10.0-desktop
+```
+
+## IDE
+
+In Visual Studio / Rider pick one of the Windows launch profiles from the debug target
+dropdown:
+
+- **App Template (WinAppSDK Packaged)** — packaged MSIX run (`commandName: MsixPackage`).
+- **App Template (WinAppSDK Unpackaged)** — unpackaged run (`commandName: Project`).
+
+> Note: a Visual Studio issue can hide the unpackaged profile when iOS/Android target
+> frameworks are present. See the
+> [Uno common issues guide](https://platform.uno/docs/articles/common-issues-vs2022.html#unable-to-select-the--myapp-unpackaged-winappsdk--profile)
+> if the profile is not selectable.

--- a/src/AppTemplate/Platforms/Windows/README.md
+++ b/src/AppTemplate/Platforms/Windows/README.md
@@ -11,11 +11,9 @@ involved at runtime on this head). See
 
 `dotnet run` support for the packaged WinAppSDK head is provided by the
 [`Microsoft.Windows.SDK.BuildTools.WinApp`](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools.WinApp)
-package (referenced for the Windows target in `AppTemplate.csproj`). Its MSBuild targets
+package, referenced for the Windows target in `AppTemplate.csproj`. Its MSBuild targets
 hook into the standard `dotnet run` pipeline: they build the project, create a
 loose-layout package, register it with Windows (like a real MSIX install) and launch it.
-This mirrors what the new `dotnet new winui` templates support — see
-[Introducing dotnet new templates for WinUI](https://devblogs.microsoft.com/ifdef-windows/introducing-dotnet-new-templates-for-winui/).
 
 ```powershell
 # From the src/AppTemplate folder
@@ -39,11 +37,13 @@ Optional MSBuild properties exposed by the package (set on the command line with
 
 ### Unpackaged (`dotnet run`)
 
-To run unpackaged, override `WindowsPackageType` so no MSIX identity is created:
+To run unpackaged, override `WindowsPackageType` so no MSIX identity is created and select
+the unpackaged launch profile explicitly (otherwise `dotnet run` picks the first
+Windows-compatible profile):
 
 ```powershell
 # From the src/AppTemplate folder
-dotnet run -f net10.0-windows10.0.26100 -p:WindowsPackageType=None
+dotnet run -f net10.0-windows10.0.26100 -p:WindowsPackageType=None --launch-profile "App Template (WinAppSDK Unpackaged)"
 ```
 
 The matching launch profile is **App Template (WinAppSDK Unpackaged)** in
@@ -64,10 +64,10 @@ dotnet run -f net10.0-desktop
 In Visual Studio / Rider pick one of the Windows launch profiles from the debug target
 dropdown:
 
-- **App Template (WinAppSDK Packaged)** — packaged MSIX run (`commandName: MsixPackage`).
 - **App Template (WinAppSDK Unpackaged)** — unpackaged run (`commandName: Project`).
+- **App Template (WinAppSDK Packaged)** — packaged MSIX run (`commandName: MsixPackage`).
 
-> Note: a Visual Studio issue can hide the unpackaged profile when iOS/Android target
-> frameworks are present. See the
-> [Uno common issues guide](https://platform.uno/docs/articles/common-issues-vs2022.html#unable-to-select-the--myapp-unpackaged-winappsdk--profile)
-> if the profile is not selectable.
+> Note: a [Visual Studio issue](https://aka.platform.uno/wasdk-maui-debug-profile-issue)
+> can hide the unpackaged profile when iOS/Android target frameworks are present. If the
+> profile is not selectable, comment out the packaged profile in
+> `Properties/launchSettings.json` until it is fixed.

--- a/src/AppTemplate/Properties/launchSettings.json
+++ b/src/AppTemplate/Properties/launchSettings.json
@@ -31,10 +31,12 @@
       "commandName": "MsixPackage",
       "compatibleTargetFramework": "windows"
     },
-    //"AppTemplate (WinAppSDK Unpackaged)": {
-    //  "commandName": "Project",
-    //  "compatibleTargetFramework": "windows"
-    //},
+    // Unpackaged run for the WinAppSDK head. Works with `dotnet run` when the project
+    // is built unpackaged, i.e. `dotnet run -f net10.0-windows10.0.26100 -p:WindowsPackageType=None`.
+    "App Template (WinAppSDK Unpackaged)": {
+      "commandName": "Project",
+      "compatibleTargetFramework": "windows"
+    },
     "App Template (Desktop)": {
       "commandName": "Project",
       "compatibleTargetFramework": "desktop"

--- a/src/AppTemplate/Properties/launchSettings.json
+++ b/src/AppTemplate/Properties/launchSettings.json
@@ -27,14 +27,15 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    // Unpackaged run for the WinAppSDK head. From the CLI, select it explicitly and build
-    // unpackaged: `dotnet run -f net10.0-windows10.0.26100 -p:WindowsPackageType=None --launch-profile "App Template (WinAppSDK Unpackaged)"`.
-    "App Template (WinAppSDK Unpackaged)": {
-      "commandName": "Project",
-      "compatibleTargetFramework": "windows"
-    },
+    // Packaged is listed first so `dotnet run -f net10.0-windows10.0.26100` defaults to it.
     "App Template (WinAppSDK Packaged)": {
       "commandName": "MsixPackage",
+      "compatibleTargetFramework": "windows"
+    },
+    // Unpackaged run for the WinAppSDK head. Explicit opt-in: select it and build unpackaged with
+    // `dotnet run -f net10.0-windows10.0.26100 -p:WindowsPackageType=None --launch-profile "App Template (WinAppSDK Unpackaged)"`.
+    "App Template (WinAppSDK Unpackaged)": {
+      "commandName": "Project",
       "compatibleTargetFramework": "windows"
     },
     "App Template (Desktop)": {

--- a/src/AppTemplate/Properties/launchSettings.json
+++ b/src/AppTemplate/Properties/launchSettings.json
@@ -27,14 +27,14 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "App Template (WinAppSDK Packaged)": {
-      "commandName": "MsixPackage",
-      "compatibleTargetFramework": "windows"
-    },
-    // Unpackaged run for the WinAppSDK head. Works with `dotnet run` when the project
-    // is built unpackaged, i.e. `dotnet run -f net10.0-windows10.0.26100 -p:WindowsPackageType=None`.
+    // Unpackaged run for the WinAppSDK head. From the CLI, select it explicitly and build
+    // unpackaged: `dotnet run -f net10.0-windows10.0.26100 -p:WindowsPackageType=None --launch-profile "App Template (WinAppSDK Unpackaged)"`.
     "App Template (WinAppSDK Unpackaged)": {
       "commandName": "Project",
+      "compatibleTargetFramework": "windows"
+    },
+    "App Template (WinAppSDK Packaged)": {
+      "commandName": "MsixPackage",
       "compatibleTargetFramework": "windows"
     },
     "App Template (Desktop)": {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,6 +4,8 @@
     <PackageVersion Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.4.2" />
     <PackageVersion Include="MZikmund.Toolkit.WinUI" Version="0.1.13-dev.43" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
+    <!-- Enables `dotnet run` for the packaged WinAppSDK (Windows) head -->
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.3.1" />
     <!-- SQLite -->
     <PackageVersion Include="sqlite-net-e" Version="1.11.0" />
     <PackageVersion Include="SourceGear.sqlite3" Version="3.50.4.5" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,6 @@
     <PackageVersion Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.4.2" />
     <PackageVersion Include="MZikmund.Toolkit.WinUI" Version="0.1.13-dev.43" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
-    <!-- Enables `dotnet run` for the packaged WinAppSDK (Windows) head -->
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.3.1" />
     <!-- SQLite -->
     <PackageVersion Include="sqlite-net-e" Version="1.11.0" />


### PR DESCRIPTION
## Summary

Enables `dotnet run` for the **WinAppSDK (Windows) head**, matching what the new `dotnet new winui` templates support (see the [Introducing dotnet new templates for WinUI](https://devblogs.microsoft.com/ifdef-windows/introducing-dotnet-new-templates-for-winui/) blog post referenced in the issue).

Closes #38

## What changed

- **`src/Directory.Packages.props`** — pin `Microsoft.Windows.SDK.BuildTools.WinApp` `0.3.1` (CPM).
- **`src/AppTemplate/AppTemplate.csproj`** — reference that package for the Windows target only (`Condition="'$(IsWinAppSdk)' == 'true'"`, `PrivateAssets="all"`). Its MSBuild targets hook into the standard `dotnet run` pipeline: build the project, prepare a loose-layout package, register it with Windows (like a real MSIX install) and launch it. This is the exact mechanism described in the blog post / `winapp` CLI docs.
- **`src/AppTemplate/Properties/launchSettings.json`** — enable the previously commented-out **App Template (WinAppSDK Unpackaged)** profile (`commandName: Project`) for unpackaged runs.
- **`src/AppTemplate/Platforms/Windows/README.md`** + **root `README.md`** — document the run commands.

## How to run

From `src/AppTemplate`:

| Head | Command |
|------|---------|
| Windows (WinAppSDK, packaged) | `dotnet run -f net10.0-windows10.0.26100` |
| Windows (WinAppSDK, unpackaged) | `dotnet run -f net10.0-windows10.0.26100 -p:WindowsPackageType=None` |
| Desktop (Skia) | `dotnet run -f net10.0-desktop` |

The project already defaults to `WindowsPackageType=MSIX`, so the packaged run needs no extra flags (requires Windows 10+ and Developer Mode / elevated terminal so the loose-layout package identity can register). Optional `WinApp*` MSBuild properties (`EnableWinAppRunSupport`, `WinAppLaunchArgs`, `WinAppRunUseExecutionAlias`, `WinAppRunNoLaunch`, `WinAppRunDebugOutput`) are documented in the Windows README.

## Build status

- `dotnet build src/AppTemplate/AppTemplate.csproj -f net10.0-desktop` — **succeeds** (0 errors; only pre-existing NU1507 / Uno0001 warnings), verified before and after the change.
- `dotnet restore` for `net10.0-windows10.0.26100` with the new package — **succeeds**; the WinApp targets import (`EnableWinAppRunSupport` evaluates `true`) and `IsWinAppSdk`/`WindowsPackageType` evaluate as expected (`true` / `MSIX`, overridable to `None`).

## Caveats

- A full packaged/unpackaged `dotnet run` of the WinAppSDK head was **not executed** in CI/headless here (no interactive Windows app session available). The configuration was validated via build + restore + MSBuild property evaluation; an end-to-end run should be confirmed on a Windows dev machine with Developer Mode enabled.
- `Microsoft.Windows.SDK.BuildTools.WinApp` `0.3.1` is current/preview tooling; bump as newer versions ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
